### PR TITLE
Switch to Snippets for including external file content

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # MkDocs
 _build
+comment.md
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/.pyspelling.yml
+++ b/.pyspelling.yml
@@ -33,6 +33,11 @@ matrix:
         - open: '{%'
           content: '[\d\D]*'
           close: '%}'
+        # Ignore the mkdocstrings calls
         - open: ':::'
+          content: '[\d\D]*'
+          close: '\n'
+        # Ignore the snippets syntax
+        - open: '-8<\-'
           content: '[\d\D]*'
           close: '\n'

--- a/.pyspelling.yml
+++ b/.pyspelling.yml
@@ -37,7 +37,11 @@ matrix:
         - open: ':::'
           content: '[\d\D]*'
           close: '\n'
-        # Ignore the snippets syntax
+        # Ignore the single line Snippets syntax
         - open: '-8<\-'
           content: '[\d\D]*'
           close: '\n'
+        # Ignore the multiline Snippets syntax
+        - open: '-8<\-\n'
+          content: '[\d\D]*'
+          close: '-8<-\n'

--- a/docs/config.yml
+++ b/docs/config.yml
@@ -76,7 +76,6 @@ markdown_extensions:
 plugins:
   search: {}
   autorefs: {}
-  include-markdown: {}
   literate-nav:
     nav_file: SUMMARY.md
   macros: {}

--- a/docs/config.yml
+++ b/docs/config.yml
@@ -64,6 +64,10 @@ markdown_extensions:
   pymdownx.blocks.caption: {}
   pymdownx.blocks.tab:
     alternate_style: true
+  pymdownx.snippets:
+    base_path: ["docs"]
+    url_download: true
+    check_paths: true
   toc:
     permalink: true
     title: On this page

--- a/docs/en/section_one/index.md
+++ b/docs/en/section_one/index.md
@@ -1,15 +1,21 @@
 # BeeWare Docs Tools Demo Section One
 
-## Include External Markdown
+## Include External Markdown from a Local File
 
-The following section should have inline code and a code block. There should
-be no text between the code block and the next header.
+The following section should have only a header, and a paragraph with inline code
+followed by a code block. There should be no text between the code block and the
+next header. This verifies that the external include extension is working with
+local files.
 
-{%
-    include-markdown "https://raw.githubusercontent.com/beeware/beeware-docs-tools/refs/heads/main/docs/include_content.md"
-    start="<!--include-markdown-content-start-->"
-    end="<!--include-markdown-content-end-->"
-%}
+-8<- "include_content.md:local-content"
+
+## Include External Markdown from a URL
+
+The following section should have only a header, some text and a Markdown list.
+This verifies that the external include extension is working, and that
+`url_download` is enabled.
+
+-8<- "https://raw.githubusercontent.com/beeware/beeware-docs-tools/refs/heads/main/docs/include_content.md:remote-content"
 
 ## Footer Navigation
 

--- a/docs/en/section_one/index.md
+++ b/docs/en/section_one/index.md
@@ -15,7 +15,7 @@ The following section should have only a header, some text and a Markdown list.
 This verifies that the external include extension is working, and that
 `url_download` is enabled.
 
--8<- "https://raw.githubusercontent.com/beeware/beeware-docs-tools/refs/heads/main/docs/include_content.md:remote-content"
+-8<- "https://raw.githubusercontent.com/kattni/beeware-docs-tools/refs/heads/tooling/snippets/docs/include_content.md:remote-content"
 
 ## Footer Navigation
 

--- a/docs/en/section_one/index.md
+++ b/docs/en/section_one/index.md
@@ -15,7 +15,9 @@ The following section should have only a header, some text and a Markdown list.
 This verifies that the external include extension is working, and that
 `url_download` is enabled.
 
--8<- "https://raw.githubusercontent.com/kattni/beeware-docs-tools/refs/heads/tooling/snippets/docs/include_content.md:remote-content"
+-8<-
+https://raw.githubusercontent.com/kattni/beeware-docs-tools/refs/heads/tooling/snippets/docs/include_content.md:remote-content
+-8<-
 
 ## Footer Navigation
 

--- a/docs/en/section_one/index.md
+++ b/docs/en/section_one/index.md
@@ -16,7 +16,7 @@ This verifies that the external include extension is working, and that
 `url_download` is enabled.
 
 -8<-
-https://raw.githubusercontent.com/kattni/beeware-docs-tools/refs/heads/tooling/snippets/docs/include_content.md:remote-content
+https://raw.githubusercontent.com/beeware/beeware-docs-tools/refs/heads/main/docs/include_content.md:remote-content
 -8<-
 
 ## Footer Navigation

--- a/docs/include_content.md
+++ b/docs/include_content.md
@@ -1,14 +1,27 @@
-<!--include-markdown-content-start-->
+# -8<- [start:local-content]
 
-### Test Include Content
+### Test including local content
 
-This content includes `inline code` and a code block.
+This content is being included from the local file. It
+includes `inline code` and a code block.
 
 ```python
 def main():
     pass
 ```
-
-<!--include-markdown-content-end-->
+# -8<- [end:local-content]
 
 This sentence should *not* be included.
+
+# -8<- [start:remote-content]
+
+### Test including remote content
+
+This content is being included remotely via URL. It
+contains a Markdown list:
+
+* List item 0
+* List item 1
+* List item 2
+
+# -8<- [start:remote-content]

--- a/docs/include_content.md
+++ b/docs/include_content.md
@@ -24,4 +24,4 @@ contains a Markdown list:
 * List item 1
 * List item 2
 
-# -8<- [start:remote-content]
+# -8<- [end:remote-content]


### PR DESCRIPTION
Snippets is a more configurable and extensible way to include external content. It is part of the Pymdownx suite, from which we are already using a number of tools. Beyond what the Macros plugin was offering, Snippets allows for including by line number, and the option to dedent content when it is included. The Snippets include syntax is also much shorter than the Macros include syntax. You can find examples of the syntax in the docs demo. A quick example of including the entire contents of `file.md`, you would add:

```
-8<- "file.md"
```

I have updated the docs demo to include both a local file and a remote file, both with delimiters to include different parts of the same file. **NOTE: The build is not going to work because the URL isn't going to be valid until it's merged.** If you want to see the build, let me know and I'll switch it to the copy on my branch temporarily. It looks about the same as the existing documentation, other than the additional test.

## PR Checklist:
 <!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
 - [x] All new features have been tested
 - [x] All new features have been documented
 - [x] I have read the **CONTRIBUTING.md** file
 - [x] I will abide by the code of conduct
