### PR TITLE
Add Markdown conversion scripts.

### DIFF
--- a/rst-to-markdown-conversion/README.md
+++ b/rst-to-markdown-conversion/README.md
@@ -1,0 +1,7 @@
+# reStructuredText to Markdown Conversion Scripts
+
+The scripts included here were used in the process of moving the BeeWare documentation
+from Sphinx reStructuredText, to Markdown and MkDocs. They are not an active part of
+the BeeWare Docs tools, and are included here purely for archival purposes. They are
+therefore not maintained or supported in any way. You are free to use and modify them
+for your own needs.

--- a/rst-to-markdown-conversion/pandoc-markdown-cleanup.py
+++ b/rst-to-markdown-conversion/pandoc-markdown-cleanup.py
@@ -1,0 +1,796 @@
+import re
+import sys
+from pathlib import Path
+
+# This was written with Toga in mind, which will be obvious looking through some of the
+# code here. That said, it works on any Pandoc `commonmark_x` converted rST, as long as
+# three changes are made to what Pandoc extensions are included with the command. It
+# needs some work; running it on Toga highlighted some syntax that it's skipping.
+
+# Run Pandoc with `commonmark_x-bracketed_spans-smart-alerts` as the output format.
+
+
+def fenced_code_language_whitespace(string):
+    """
+    Removes the space between the initial code fence and the code language.
+
+    Test string:
+    string = "``` language"
+    """
+    return re.subn(r"``` (.+)\n", r"```\1\n", string)
+
+
+def group_tabs(string):
+    """
+    Begins first tab in group tab content.
+
+    Test string:
+    string = ":::::::::: {.tabs}\n::: {.group-tab}\n"
+    """
+    return re.subn(r":+ {\.tabs}\n::: {\.group-tab}\n", r"/// tab | ", string)
+
+
+def intermediate_group_tabs(string):
+    """
+    In group tab content, terminates the first and second tab, and begins
+    the second and third tab.
+
+    Test string:
+    string = ":::\n\n:::: {.group-tab}\n"
+    """
+    return re.subn(r":{3,4}\n\n:{3,4} {.group-tab}\n", r"\n///\n\n/// tab | ", string)
+
+
+def end_tab_nested_admonition(string):
+    """
+    Terminates tabbed section with nested admonition.
+
+    Test string:
+    string = "::::\n:::::::"
+    """
+    return re.subn(r":{4}\n:{7}", r"\n///\n\n///\n", string)
+
+
+def end_group_tabs(string):
+    """
+    Terminates group tab sections.
+
+    Test string:
+    string = ":::\n::::::"
+    """
+    return re.subn(r":{3}\n:{6,10}", r"\n///", string)
+
+
+def note(string):
+    """
+    Format `note` admonitions - will also work with attention,
+    caution, danger, error, tip, hint, warning admonition types.
+
+    Test string:
+    # string = ":::: {.note}\n::: {.title}\nNote\n:::\n\nIf you're using a recent version of Android, you may notice that the app\nicon has been changed to a green snake, but the background of the icon\nis *white*, rather than light blue. We'll fix this in the next step.\n::::"
+    """
+    return re.subn(
+        r":::: \{\.([a-z]+)}\n::: \{\.title}\n([a-zA-Z]+)\n:::\n\n([\d\D]*?)\n::::",
+        r"/// \1 | \2\n\n\3\n\n///",
+        string,
+    )
+
+
+def admonition(string):
+    """
+    Format admonitions.
+
+    Test string:
+    # string = "::: {.admonition}\nText that is sometimes multiple words\n\nContent - often\nmultiline\n:::"
+    """
+    return re.subn(
+        r"::: \{\.(admonition)}\n([\d\D]*?)\n\n([\d\D]*?):::",
+        r"/// \1 | \2\n\n\3\n\n///",
+        string,
+    )
+
+
+def header_anchors(string):
+    """
+    Formats headers and header anchors. If anchor text matches header text, anchor is
+    removed, as Markdown generates matching anchors by default. If anchor text does
+    not match header text, anchor is replaced with attr-plugin formatted version.
+
+    Some of these text strings aren't applicable anymore; the initial Pandoc run was
+    adding custom anchors to everything, not only where they already existed. I
+    excluded that extension from the Pandoc command.
+
+    TODO: UPDATE THIS TO MATCH PROPER FORMATTING
+    TODO: RUN BEFORE docs_links_header_and_text.
+
+    Test strings:
+    string = {
+    "string_one": "# Header text {#foo}",
+    "string_two": "# Header text {#header-text}",
+    "string_three": "# Header text - with dash... {#header-text---with-dash...}",
+    "string_four": '# `~header.Text.FOO`{.interpreted-text role="attr"} {#header.text.foo}',
+    "string_five": '# `~header.text`{.interpreted-text role="class"} {#header.text}',
+    }
+    """
+    matches = re.findall(
+        r"((#+) ([`~]*)([A-Za-z0-9\- .]*)(?:`*)(?:{.interpreted-text role=\")?([A-Za-z]*)?(?:\"})?(?: )?(?:\{)?(#+)?([a-z0-9\-.]*)(?:\})?)",
+        string,
+    )
+
+    subs = 0
+    for match in matches:
+        comparison_string = (
+            match[3].lower().rstrip(" ").replace(".", "-").replace(" ", "-")
+        )
+        if "..." in match[6]:
+            replacement_string = f"{match[0]} {match[3]}"
+        elif match[2] == "" and match[6] != "" and comparison_string == match[6]:
+            replacement_string = f"{match[1]} {match[2]}"
+        elif match[2] == "" and match[6] != "" and comparison_string != match[6]:
+            replacement_string = f'{match[1]} {match[3]} {{ id="{match[6]}" }}'
+        elif match[2] == "`~" and match[6] == match[3].lower():
+            replacement_string = f"{match[1]} `{match[3]}`"
+            print(f"{replacement_string} is type {match[4]}")
+        elif match[2] == "`~" and match[6] != match[3].lower():
+            replacement_string = f'{match[1]} `{match[3]}` {{ "id={match[6]}" }}'
+            print(f"{replacement_string} is type {match[4]}")
+        else:
+            replacement_string = None
+
+        if replacement_string:
+            string = string.replace(match[0], replacement_string)
+            subs += 1
+
+    return string, subs
+
+
+def external_doc_links(string):
+    """
+    Update external to autorefs format.
+
+    Links list below no longer needed as autorefs automatically links to the
+    Python/Pillow docs.
+
+    TODO: RUN BEFORE docs_links_header_and_text.
+
+    Test strings:
+    strings = [
+        '`pathlib.Path`{.interpreted-text role="any"}',
+        '`list`{.interpreted-text role="any"}',
+        '`memoryview`{.interpreted-text role="any"}',
+        '`bytearray`{.interpreted-text role="any"}',
+        '`bytes`{.interpreted-text role="any"}',
+        '`str`{.interpreted-text role="any"}',
+        '`tuple`{.interpreted-text role="any"}',
+        '`None`{.interpreted-text role="any"}',
+        '`datetime.date`{.interpreted-text role="any"}',
+        '`datetime.datetime`{.interpreted-text role="any"}',
+        '`~decimal.Decimal`{.interpreted-text role="class"}',
+        '`int`{.interpreted-text role="any"}',
+        '`float`{.interpreted-text role="any"}',
+        '`importlib.metadata`{.interpreted-text role="any"}',
+        '`PermissionError`{.interpreted-text role="any"}',
+        '`asyncio.Task`{.interpreted-text role="any"}',
+        '`PIL.Image.Image`{.interpreted-text role="any"}',
+    ]
+    """
+    # links = {
+    #     "`pathlib.Path`": "https://docs.python.org/3/library/pathlib.html#pathlib.Path",
+    #     "`list`": "https://docs.python.org/3/library/stdtypes.html#list",
+    #     "`memoryview`": "https://docs.python.org/3/library/stdtypes.html#memoryview",
+    #     "`bytearray`": "https://docs.python.org/3/library/stdtypes.html#bytearray",
+    #     "`bytes`": "https://docs.python.org/3/library/stdtypes.html#bytes",
+    #     "`str`": "https://docs.python.org/3/library/stdtypes.html#str",
+    #     "`tuple`": "https://docs.python.org/3/library/stdtypes.html#tuple",
+    #     "`None`": "https://docs.python.org/3/library/constants.html#None",
+    #     "`datetime.date`": "https://docs.python.org/3/library/datetime.html#datetime.date",
+    #     "`datetime.datetime`": "https://docs.python.org/3/library/datetime.html#datetime.datetime",
+    #     "`Decimal`": "https://docs.python.org/3/library/decimal.html#decimal.Decimal",
+    #     "`int`": "https://docs.python.org/3/library/functions.html#int",
+    #     "`float`": "https://docs.python.org/3/library/functions.html#float",
+    #     "`importlib.metadata`": "https://docs.python.org/3/library/importlib.metadata.html#module-importlib.metadata",
+    #     "`PermissionError`": "https://docs.python.org/3/library/exceptions.html#PermissionError",
+    #     "`asyncio.Task`": "https://docs.python.org/3/library/asyncio-task.html#asyncio.Task",
+    #     "`PIL.Image.Image`": "https://pillow.readthedocs.io/en/stable/reference/Image.html#PIL.Image.Image",
+    # }
+
+    strings = [
+        '`pathlib.Path`{.interpreted-text role="any"}',
+        '`list`{.interpreted-text role="any"}',
+        '`memoryview`{.interpreted-text role="any"}',
+        '`bytearray`{.interpreted-text role="any"}',
+        '`bytes`{.interpreted-text role="any"}',
+        '`str`{.interpreted-text role="any"}',
+        '`tuple`{.interpreted-text role="any"}',
+        '`None`{.interpreted-text role="any"}',
+        '`datetime.date`{.interpreted-text role="any"}',
+        '`datetime.datetime`{.interpreted-text role="any"}',
+        '`~decimal.Decimal`{.interpreted-text role="class"}',
+        '`int`{.interpreted-text role="any"}',
+        '`float`{.interpreted-text role="any"}',
+        '`importlib.metadata`{.interpreted-text role="any"}',
+        '`PermissionError`{.interpreted-text role="any"}',
+        '`asyncio.Task`{.interpreted-text role="any"}',
+        '`PIL.Image.Image`{.interpreted-text role="any"}',
+    ]
+
+    matches = re.findall(
+        r'((`)(~decimal.)?([A-Za-z.`]+){.interpreted-text(?:[ \n]*)?role="(?:[a-z]+)"})',
+        string,
+    )
+
+    subs = 0
+    for match in matches:
+        if match[3] in "".join(strings) and match[3] != "Image`":
+            replacement_string = f"[{match[1]}{match[3]}][]"
+        elif match[3] == "Image`":
+            replacement_string = "[`toga.Image`][]"
+        elif match[3] == "ImageConverter`":
+            replacement_string = "[`toga.images.ImageConverter`][]"
+        elif match[2] == "~decimal.":
+            replacement_string = "[`Decimal`][]"
+        else:
+            replacement_string = None
+        if replacement_string:
+            string = string.replace(match[0], replacement_string)
+            subs += 1
+
+    return string, subs
+
+
+def doc_links_header_and_text(string):
+    """
+    Convert doc, ref, method, etc. links. Where applicable, strip leading `/` and `/index`.
+
+    For `role="ref"`, if anchor and header do not match, replace anchor with
+    attr-plugin formatted version.
+
+    TODO: Get actual test strings, and sort out the autoref formats for them.
+
+    Test strings:
+    strings = {
+        "string_one": '`a hands-on introduction to Toga </tutorial/index>`{.interpreted-text role="doc"}',
+        "string_two": '## `How-to guides <how-to/index>`{.interpreted-text role="ref"}',
+        "string_three": '`overall architectural details </reference/internals/index>`{.interpreted-text role="doc"}',
+        "string_four": '`the \ndocumentation on document handling <./resources/document>`{.interpreted-text\n role="doc"}',
+        "string_five": '`~toga.Bar.baz`{.interpreted-text role="meth"}',
+        "string_six": '`Foo <path/bar>`{.interpreted-text role="buzz"}',
+        "string_seven": '`Foo <bar>`{.interpreted-text role="baz"}',
+        "string_eight": '## `Text <ref-header-name>`{.interpreted-text role="ref"}',
+        "string_nine": '## `Ref header name <ref-header-name>`{.interpreted-text role="ref"}',
+        "string_ten": '`installed all the platform pre-requisites\n<install-dependencies>`{.interpreted-text role="ref"}'
+    }
+    """
+    matches = re.findall(
+        r"((#*)?( )?`(~)?([A-Za-z0-9\n. \-_!'\"]*)(?:\(\))?(?:<)?(?:\/)?([.a-z0-9\/\-]*)?>?`{.interpreted-text(?:\n)?(?: )?role=\"([a-z]+)\"})",
+        string,
+    )
+
+    subs = 0
+    replacement_string = None
+    for match in matches:
+        trimmed_content = match[4].rstrip()
+        print(trimmed_content)
+        if (
+            match[6] == "download"
+        ):  # There's a download link that gets wrapped up in a different block if not dealt with here
+            replacement_string = f"[{trimmed_content}]({match[5]})"
+        elif (match[6] == "ref" or match[6] == "doc") and match[
+            6
+        ] != "download":  # If the type is `ref` or `doc`, but not `download`
+            comparison_string = match[5].replace(
+                "-", " "
+            )  # Pull the path to compare to the link text
+            if (
+                comparison_string == match[4].rstrip().lower() and "#" in match[1]
+            ):  # Does the header link text match the path
+                replacement_string = (
+                    f"{match[1]}{trimmed_content}"  # Header is all that is needed
+                )
+            elif (
+                comparison_string != match[4].rstrip().lower()
+                and "/index" not in match[5]
+            ):  # Link text does not match path and no index in path
+                if match[1] and "#" in match[1]:  # It's a header
+                    replacement_string = f'{match[1]}[{trimmed_content}] {{ id="{match[5]}" }}'  # Update custom header anchor to autodoc format
+                elif match[5] and "/" in match[5]:  # Text with a path that is not index
+                    replacement_string = f"{match[2]}[{match[4].replace('\n', ' ').rstrip()}]({match[5]})"  # Made into link format
+                else:  # Text with a non-matching anchor
+                    replacement_string = f"{match[2]}[{match[4].replace('\n', ' ').rstrip()}][{match[5]}]"  # Made into autodoc format
+            elif (
+                match[1] and "#" in match[1] and "/index" in match[5]
+            ):  # Header with index in the path
+                comparison_string = (
+                    match[5].removesuffix("/index").replace("-", " ")
+                )  # Strip `/index` off path, and prepare for comparison to header text
+                if (
+                    comparison_string != trimmed_content.lower()
+                ):  # If the header text doesn't match the path without `/index`
+                    replacement_string = f'{match[1]}[{trimmed_content}] {{ id="{match[5].removesuffix("/index")}" }}'  # Create header link with reference ID
+                else:  # If header text matches path
+                    replacement_string = (
+                        f"{match[1]}[{trimmed_content}]"  # Create bare header
+                    )
+            elif not match[1] and "/index" in match[5]:  # Not a header, index in path
+                replacement_string = f"{match[2]}[{match[4].replace('\n', ' ').rstrip()}]({match[5].removesuffix('/index')})"  # Create link without `/index`
+        elif "toga" in match[4] and match[6] == "meth":  # Type `meth`
+            if match[3] == "~":  # `~` name only
+                class_name = match[4].split(
+                    "."
+                )  # Split the method name to generate `~` name
+                replacement_string = f"{match[2]}[`{class_name[(len(class_name) - 1)]}()`][{trimmed_content}]"  # `~` name in autoref format with `()`
+            else:  # Full name
+                replacement_string = f"{match[2]}[`{trimmed_content}()`][{trimmed_content}]"  # Autoref format with `()`
+        elif (
+            "toga" in match[4] and match[6] != "meth"
+        ):  # Class name but not type `meth`
+            if match[3] == "~":  # ~ name only
+                class_name = match[4].split(
+                    "."
+                )  # Split the method name to generate `~` name
+                replacement_string = f"{match[2]}[`{class_name[(len(class_name) - 1)]}`][{trimmed_content}]"  # `~` name in autoref format
+            else:  # Full class name
+                replacement_string = (
+                    f"{match[2]}[`{trimmed_content}`][]"  # autoref format
+                )
+        elif "/" not in match[5]:  # The link is a reference ID, not a URL
+            replacement_string = f"{match[2]}[{trimmed_content}][{match[5]}]"  # Autoref format with reference ID
+        elif (
+            "toga" not in match[4] and match[4][0].islower()
+        ):  # This is most likely a missed external reference
+            replacement_string = f"{match[2]}[{trimmed_content}][]<!-- TODO: Verify this is an accurate link -->"  # Verify whatever this was is accurate
+        elif (
+            "toga" not in match[4] and (match[4][0].isupper() or match[4][1].isupper())
+        ):  # A Toga reference without the full name, beginning with `.` or not (49 at time of writing)
+            replacement_string = f"{match[2]}[{trimmed_content}][{trimmed_content}]<!-- TODO: Update to full reference -->"  # Manually fix afterwards.
+
+        if replacement_string:
+            string = string.replace(match[0], replacement_string)
+            subs += 1
+
+    return string, subs
+
+
+def literal_include(string):
+    """
+    Convert rST literal includes to Markdown using Macros plugin format.
+
+    Test string:
+    string = ' {.literalinclude language="python"}\n/../examples/tutorial4/tutorial/app.py\n'
+    """
+    return re.subn(
+        r"::: {.literalinclude language=\"([a-z]+)\"}\n/../examples/([a-z0-9]+)/tutorial/app.py\n:::",
+        r'```\1\n{% include "../../examples/\2/tutorial/app.py" %}\n```',
+        string,
+    )
+
+
+def auto_module_function_class(string):
+    """
+    Convert autodoc directives to mkdocstrings. In special cases,
+    includes instructions on adding appropriate members list.
+
+    Test strings:
+    strings = [
+        '::: {.autoclass}\ntoga.Foo\n:::',
+        '::: {.autoprotocol}\ntoga.Foo\n:::',
+        '::: {.namedtuple}\ntoga.Foo\n:::',
+        '::: {.autoclass exclude-members="bar, baz"}\ntoga.Foo\n:::',
+        '::: {.autoclass special-members="bar, baz"}\ntoga.Foo\n:::',
+    ]
+    """
+
+    matches = re.findall(
+        r"((:{3,6} {\.)([a-z]*?)( )?([a-zA-Z\-=]*?)?([a-zA-Z, \"_\n]*?)?(}\n)([a-zA-Z.]*?)?(\n:::))",
+        string,
+        flags=re.MULTILINE,
+    )
+
+    subs = 0
+    for match in matches:
+        if match[4]:
+            if "exclude-members" in match[4]:
+                replacement_string = f"::: {match[7]}\n    options:\n        members:\n            TODO: Add explicit members list excluding {match[5]}"
+            elif "member-order" in match[4]:
+                replacement_string = f"::: {match[7]}\n    options:\n        members:\n            TODO: Add explicit members list in the following order {match[5]}"
+            elif "special-members" in match[4]:
+                replacement_string = f"::: {match[7]}\n    options:\n        members:\n            TODO: Add explicit members list *excluding* special members *except* for {match[5]}"
+            elif "inherited-members" in match[4]:
+                replacement_string = f"::: {match[7]}\n    options:\n        members:\n            TODO: Do I need to add inherited members list including {match[5]}?"
+        elif "namedtuple" in match[3]:
+            replacement_string = f"::: {match[7]}\n    options:\n        members:\n            TODO: Add full members list"
+        else:
+            replacement_string = f"::: {match[7]}"
+
+        if replacement_string:
+            string = string.replace(match[0], replacement_string)
+            subs += 1
+
+    return string, subs
+
+
+def spelling_ignore(string):
+    """
+    TODO: Update this for pyspelling syntax.
+    Tag inline `codespell:ignore` directives to be shifted to the ignore words file.
+
+    Test string:
+    string = '`foo`{.interpreted-text role="spelling:ignore"}'
+    """
+    return re.subn(
+        r"`([A-Za-z]+)(.+)(spelling:ignore)",
+        r"\1<!-- TODO: Add to spelling_wordlist.txt file -->",
+        string,
+    )
+
+
+def toctree(string):
+    """
+    Generates list of links from toctree entries. Removes hidden toctree entries
+    as the toctrees are automatically generated by MkDocs and Material theme.
+    Includes instructions to verify links, and add page headings if `maxdepth=2`.
+
+    Test strings:
+    strings = [
+        '::: {.toctree maxdepth="1"}\nfoo bar baz\n:::',
+        '::: {.toctree maxdepth="2" glob=""}\nfoo bar baz\n:::',
+        '::: {.toctree}\nfoo bar/index baz/page\n:::',
+        '::: {.toctree maxdepth="2" hidden="" titlesonly=""}\nfoo bar/index baz/page\n:::',
+    ]
+    """
+
+    matches = re.findall(
+        r"(::: {.toctree([A-Za-z0-9=\" ]+)?}\n([a-zA-Z0-9_\/ \-\n]+)\n:::)", string
+    )
+
+    subs = 0
+    for match in matches:
+        if match[1] and "hidden" not in match[1]:
+            if match[1] and 'maxdepth="2"' in match[1]:
+                todo = "TODO: Check on links, add page headings?"
+            else:
+                todo = "TODO: Check text on links."
+            toctree_string = []
+            split_links = f"{match[2]}"
+            split_link_list = split_links.split(" ")
+            for link in split_link_list:
+                if "/" in link:
+                    link_name = link.split("/")[1]
+                    if link_name == "index":
+                        link_name = link.split("/")[0]
+                        link_string = f"[{link_name.title()}](./{link}.md)"
+                        toctree_string.append(link_string)
+                    else:
+                        link_string = f"[{link_name.title()}](./{link}.md)"
+                        toctree_string.append(link_string)
+                else:
+                    link_string = f"[{link.title()}](./{link})"
+                    toctree_string.append(link_string)
+            replacement_string = f"{'\n'.join(toctree_string)}\n{todo}"
+        else:
+            replacement_string = "\n"
+
+        if replacement_string:
+            string = string.replace(match[0], replacement_string)
+            subs += 1
+
+    return string, subs
+
+
+def platform_support_indicators(string):
+    """
+    Update platform support indicators on support tables to current format.
+
+    Test strings contain invalid escape sequences.
+    See toga/docs/reference/api/widgets/table.md for instances of no and beta examples.
+    """
+
+    matches = re.findall(r"(\[\\\|([a-z]+)\\\|\]\(##SUBST##\|(?:[a-z]+)\|\))", string)
+
+    subs = 0
+    for match in matches:
+        if match[1] == "beta":
+            replacement_string = "{{ beta_support }}"
+        elif match[1] == "no":
+            replacement_string = "{{ not_supported }}"
+        else:
+            replacement_string = None
+
+        if replacement_string:
+            string = string.replace(match[0], replacement_string)
+            subs += 1
+
+    return string, subs
+
+
+def text_above_mkdocstrings(string):
+    """
+    In the event of text occurring above current autodoc directives,
+    add instructions to verify that the text block is not intended to
+    be part of the source code. Example: ImageContentT.
+
+    Test string:
+    string = ## Reference
+
+    > An item of `OptionContainer`{.interpreted-text role="any"} content can
+    > be:
+    >
+    > - a 2-tuple, containing the title for the tab, and the content widget;
+    > - a 3-tuple, containing the title, content widget, and
+    >   `icon <IconContentT>`{.interpreted-text role="any"} for the tab;
+    > - a 4-tuple, containing the title, content widget,
+    >   `icon <IconContentT>`{.interpreted-text role="any"} for the tab, and
+    >   enabled status; or
+    > - an `toga.OptionItem`{.interpreted-text role="any"} instance.
+
+    :::
+    """
+
+    result = re.search(r"(## Reference\n)\n([\d\D]*?):::", string)
+    if result and result.group(2):
+        return re.subn(
+            r"(## Reference\n)\n([\d\D]*?):::",
+            r"\1TODO: Verify the below text is not meant to be in the source code:\n\2:::",
+            string,
+        )
+    return string, 0
+
+
+def remove_rst_class_from_widget_pages(string):
+    """
+    Remove rst-class directive from widget tables.
+
+    Test strings:
+    """
+    #     strings = [
+    #         """::: {.rst-class}
+    # widget-support
+    # :::""",
+    #         """::: {.rst-class}
+    # widget-descriptions
+    # :::"""
+    #         ]
+
+    return re.subn(r"\n::: {.rst-class}\nwidget-([a-z]+)\n:::\n", r"", string)
+
+
+def csv_table_widget_pages(string):
+    """Convert CSV tables on individual widget pages to updated format.
+
+    TODO: Update .csv to have Markdown reference links, rename first
+        column to "Component Name", replace "stable"/"etc" with the
+        graphic dots. Partial update in toga-mkdocs.
+
+    Test string:
+    string = ::: {.csv-filter header-rows="1" file="../../data/widgets_by_platform.csv" included_cols="0,1,2,3,4,5" include="{0: '^Foo$'}"}
+    Availability (`Key <api-status-key>`{.interpreted-text role="ref"})
+    :::
+    """
+
+    replacement_string = r'Availability ([Key][api-status-key])\n\n{{ pd_read_csv("reference/data/widgets_by_platform.csv", na_filter=False, usecols=[\1])[pd_read_csv("reference/data/widgets_by_platform.csv")[["ComponentName"]].isin(["\2"]).all(axis=1)] | convert_to_md_table }}'
+
+    return re.subn(
+        r"::: \{.csv-filter header-rows=\"1\" file=\"(?:[\.\/a-z_]+)\" included_cols=\"([0-9,]+)\" include=\"\{0: '\^([A-Za-z ]+)\$'\}\"\}\nAvailability \(`Key <api-status-key>`\{.interpreted-text role=\"ref\"\}\)\n:::",
+        replacement_string,
+        string,
+    )
+
+
+def csv_table_widgets_by_platform(string):
+    """Convert CSV tables on Widgets by Platform page to updated format.
+
+    TODO: Update .csv to have Markdown reference links, rename first
+        column to "Component Name", replace "stable"/"etc" with the
+        graphic dots. Partial update in toga-mkdocs.
+
+    Test string:
+    string = ::: {.csv-filter .longtable file="data/widgets_by_platform.csv" header-rows="1" exclude="{1: '(?!(Type|Layout Widget))'}" included_cols="2,4,5,6,7,8,9,10" stub-columns="1" widths="3 1 1 1 1 1 1 1"}
+    :::
+    """
+
+    replacement_string = r'{{ pd_read_csv("reference/data/widgets_by_platform.csv", na_filter=False, usecols=[\2])[pd_read_csv("reference/data/widgets_by_platform.csv")[["Type"]].isin(["\1"]).all(axis=1)] | convert_to_md_table }}'
+    return re.subn(
+        r"::: \{.csv-filter .longtable file=\"(?:[\.\/a-z_]+)\" header-rows=\"1\" exclude=\"\{1: \'\(\?\!\(Type\|([a-zA-Z ]+)\)\)\'\}\" included_cols=\"([0-9,]+)\" stub-columns=\"1\" widths=\"3 1 1 1 1 1 1 1\"\}\n:::",
+        replacement_string,
+        string,
+    )
+
+
+def aligned_image(string):
+    """Convert Markdown image with align specified to HTML figure.
+
+    Test strings:
+    strings = [
+        "![Hello World Tutorial 8 dialog, on Linux](images/linux/tutorial-8.png){.align-center}",
+        "![Hello World Tutorial 8 dialog, on Windows](images/windows/tutorial-8.png){.align-center}",
+    ]
+    """
+
+    return re.subn(
+        r"(![\d\D]*?)(\([\d\D]*?\))\{\.align-center\}",
+        r"\1\2\n\n\\\\\\ caption\n\n\\\\\\\n\n",
+        string,
+    )
+
+
+def markdown_image_with_width(string):
+    """
+    Convert Markdown image with width specified to HTML figure.
+
+    Test strings:
+    """
+    #     strings = [
+    #         """![image](/reference/screenshots/winforms.png){.align-center
+    # width="300px"}""",
+    #         '![image](/reference/screenshots/gtk.png){.align-center width="300px"}'
+    #     ]
+
+    return re.subn(
+        r"(![\d\D]*?)(\([\d\D]*?\))\{\.(?:[a-z\-]+)(?: )?(?:\n)?(?:width=\")([0-9a-z]+)?\"\}",
+        r'\1\2{ width="\3" }\n<!-- TODO: Update alt text -->',
+        string,
+    )
+
+
+def figure(string):
+    """
+    Convert HTML figure to Markdown image syntax. Add note to update alt-text if it is
+    set to be the image path.
+
+    Test strings:
+    """
+    # """
+    # <figure class="align-center">
+    # <img src="/reference/images/canvas-cocoa.png" width="300"
+    # alt="/reference/images/canvas-cocoa.png" />
+    # </figure>
+    # """
+    # """
+    # <figure class="align-center">
+    # <img src="screenshots/tutorial-3.png" width="300"
+    # alt="screenshots/tutorial-3.png" />
+    # </figure>
+    # """
+
+    matches = re.findall(
+        r'(<figure( class="align\-center")?>\n<img src="([\d\D]*?)"( width="([0-9]*)")?\nalt="([\d\D]*?)" \/>\n<\/figure>)',
+        string,
+    )
+
+    subs = 0
+    for match in matches:
+        if match[2] == match[5]:
+            todo = "\n<!-- TODO: Update alt text -->"
+        else:
+            todo = ""
+        if "align-center" in match[1] and "width" not in match[3]:
+            replacement_string = (
+                f"![{match[5]}]({match[2]})\n\n/// caption\n\n///n\n{todo}"
+            )
+        elif "width" in match[3] and "align-center" not in match[1]:
+            replacement_string = (
+                f'![{match[5]}]({match[2]}){{ width="{match[4]}" }}{todo}'
+            )
+        elif "align-center" in match[1] and "width" in match[3]:
+            replacement_string = f'![{match[5]}]({match[2]}){{ width="{match[4]}" }}\n\n/// caption\n\n///\n\n{todo}'
+
+        if replacement_string:
+            string = string.replace(match[0], replacement_string)
+            subs += 1
+
+    return string, subs
+
+
+def dash_item(string):
+    """
+    Remove directive notation on -item blocks.
+
+    Test strings:
+    """
+    #     strings = [
+    #         """::: {#treesource-item}
+    # When creating a single Node for a TreeSource (e.g., when inserting a new
+    # item), the data for the Node can be specified as:
+    # :::""",
+    #         """::: {#listsource-item}
+    # The ListSource manages a list of `~toga.sources.Row`{.interpreted-text
+    # role="class"} objects. Each Row has all the attributes described by the
+    # source's `accessors`. A Row object will be constructed for each item
+    # that is added to the ListSource, and each item can be:
+    # :::"""
+    #     ]
+
+    return re.subn(r"::: \{#(?:[a-z\-]+)\}\n([\d\D]*?):::", r"\1", string)
+
+
+def doc_ref_any(string):
+    """
+    TODO: Fix this so it actually converts all of them.
+    Grabs the last of the :notation: links that were missed above, including `doc`,
+    `ref` and `any` links. Doesn't work on all of them due to the regex, so those that
+    are still left are tagged with "Manually fix this".
+    """
+    matches = re.findall(
+        r'(`([\d\D]*?)(?: )?(?:\n)?<([\d\D]*?)>`{.interpreted-text(?:\n)?(?:[ ]*)?role="([a-z]+)"})',
+        string,
+    )
+
+    subs = 0
+    for match in matches:
+        if "`" in match[1]:
+            replacement_string = f"{match[0]} - TODO: Manually fix this"
+        elif "/" in match[2]:
+            replacement_string = f"[{match[1]}]({match[2]})"
+        else:
+            replacement_string = f"[{match[1]}][{match[2]}]"
+
+        if replacement_string:
+            string = string.replace(match[0], replacement_string)
+            subs += 1
+
+    return string, subs
+
+
+def markdown_reference_fix(string):
+    """
+    Initially forgot to include backticks on the code reference autoref links.
+    This fixes that. Leaving it in here in case the update to the method above
+    that handles the autoref links missed anything.
+    """
+    matches = re.findall(r"(\[([\d\D]*?)\]\[([\d\D]*?)\])", string)
+    subs = 0
+    for match in matches:
+        if "toga" in match[1] and match[2] == "":
+            replacement_string = f"[`{match[1]}`][]"
+        elif "toga" not in match[1] and "." in match[2]:
+            replacement_string = f"[`{match[1]}`][{match[2]}]"
+        else:
+            replacement_string = f"{match[0]}"
+
+        if replacement_string:
+            string = string.replace(match[0], replacement_string)
+            subs += 1
+
+    return string, subs
+
+
+def convert(path):
+    content = path.read_text()
+
+    for method in [
+        # remove_rst_class_from_widget_pages,
+        # csv_table_widget_pages,
+        # csv_table_widgets_by_platform,
+        # fenced_code_language_whitespace,
+        # group_tabs,
+        # intermediate_group_tabs,
+        # end_tab_nested_admonition,
+        # end_group_tabs,
+        # header_anchors,
+        # note,
+        # admonition,
+        # literal_include,
+        # auto_module_function_class,
+        # external_doc_links,
+        # doc_links_header_and_text,
+        # toctree,
+        # platform_support_indicators,
+        # text_above_mkdocstrings,
+        # aligned_image,
+        # markdown_image_with_width,
+        # figure,
+        # dash_item,
+        # doc_ref_any,
+    ]:
+        print(method.__name__, end=" ")
+
+        content, subs = method(content)
+        print("." * subs)
+
+    Path(path.parent / (path.name)).write_text(content)
+
+
+if __name__ == "__main__":
+    for path in Path(sys.argv[1]).glob("**/*.md"):
+        print("=" * 5 + str(path) + "=" * 20)
+        convert(path)

--- a/rst-to-markdown-conversion/translation_conversion.py
+++ b/rst-to-markdown-conversion/translation_conversion.py
@@ -1,0 +1,135 @@
+import re
+import sys
+from pathlib import Path
+
+# A major caveat: if the links in the translations are not properly formatted, this
+# script will not function as expected, and will likely result in half-updated links
+# or links that are missed entirely. Link issues I encountered: links wrapped in double
+# quotes instead of backticks, links with spaces in them, links missing one of the
+# backticks, links missing both backticks, and links followed by only one underscore.
+# There are endless ways links can be misformatted. I went through the PO files and
+# manually fixed as many of the issues as I could find by searching for various link
+# syntax pieces in the files. This method is not guaranteed to find everything, for
+# obvious reasons, but it was a good start.
+
+
+def doc_links(string):
+    """
+    Update doc links to Markdown formatting.
+    """
+    return re.subn(
+        r":doc:(?<!`)`(?!`)([\d\D']*?) <([a-zA-Z0-9-:\/\.# _]+)(?:>`)",
+        r"[\1][\2]",
+        string,
+    )
+
+
+def download_links(string):
+    """
+    Update download links to Markdown formatting, add note to manually verify path, as
+    the relative link needed for the Markdown to be happy may not match.
+    """
+    return re.subn(
+        r":download:(?<!`)`(?!`)([\d\D']*?) <([a-zA-Z0-9-:\/\.# _]+)(?:>`)",
+        r"[\1](\2) (TODO: Verify path.)",
+        string,
+    )
+
+
+def ref_links(string):
+    """
+    Update rST reference links to MkDocs autorefs format.
+    """
+    return re.subn(r":ref:`([\d\D]+?)<([\d\D]+?)(>`?)", r"[\1][\2]", string)
+
+
+def double_colon(string):
+    """
+    Update double-colon rST code directive to single for Markdown formatting.
+    """
+    return re.subn(r"::", r":", string)
+
+
+def links_rst_to_markdown(string):
+    """
+    Convert rST links to Markdown links in translation files.
+
+    Test strings:
+    string = 'msgid "Si no se siente cómodo con el inglés, las traducciones de este tutorial están disponibles en `Alemán <https://docs.beeware.org/de>`__, `Español <https://docs.beeware.org/es>`__, `Français <https://docs.beeware.org/fr>`__, `Italiano <https://docs.beeware.org/it>`__, `Português <https://docs.beeware.org /pt>`__, `中文(简体) <https://docs.beeware.org/zh-cn>`__ y `中文(繁體) <https://docs.beeware.org/zh-tw>`__."'
+    string = 'msgstr "**Git**, a version control system `git-scm.com <https://git-scm.com/downloads/>`__. You can download Git from from `git-scm.com <https://git-scm.com/downloads/>`__."'
+    string = "`Toga <https://toga.beeware.org>`__, a cross platform widget toolkit;"
+    string = "Cuando esté listo para publicar una aplicación real, consulte la guía práctica de Briefcase sobre `Cómo configurar una identidad de firma de código de macOS <https://briefcase.readthedocs.io/en/latest/how-to/code-signing/macOS.html>`__"
+    string = "`Toga <https://toga.beeware.org>`__"
+    string = "`Toga <https://toga.beeware.org>`__ `Toga <https://toga.beeware.org>`__"
+    """
+
+    return re.subn(
+        r"(?<!`)`(?!`)([\d\D']*?) <([a-zA-Z0-9-:\/\.#` `_=\?\+\%]+)(?:>`_{1,2})",
+        r"[\1](\2)",
+        string,
+    )
+
+
+def inline_code_rst_to_markdown(string):
+    """
+    Convert rST inline code formatting to Markdown inline code formatting.
+
+    TODO: RUN LINK UPDATES FIRST.
+    """
+
+    return re.subn(r"``([\d\D]*?)``", r"`\1`", string)
+
+
+def link_placeholders(string):
+    """
+    Replaces all link URLs with `{1}` placeholder.
+
+    TODO: This requires manual intervention afterward to update all strings with
+          multiple links to have sequential numbers.
+
+    TODO: RUN LAST.
+
+    Links are represented in the PO files with `{#}` placeholders. The first link would
+    be `[Link text]{1}`, for example. In a string with multiple links, each
+    subsequent value is incremented by one. A string with four links would have `[]{1}`,
+    `[]{2}`, `[]{3}`, and `[]{4}` within it.
+
+    I was unable to sort out how to successfully do this programmatically. So I replaced
+    them all with {1}, and searched for `{#}` beginning with 6, as the English Markdown
+    was accurately numbered. I continued searching one less each time through 2 to
+    ensure I updated all the placeholders properly; most of the strings contained only
+    one link, so I concluded that it would be faster to do it manually than to continue
+    trying to sort out the code to do it.
+
+    NOTE: I could have simply replaced the link targets with `{#}` in the
+    links_rst_to_markdown() function, however, leaving the links intact initially meant
+    it was easier to identify the broken links. Running this separately was basically a
+    safeguard.
+    """
+    return re.subn(r"((\(https:\/\/)([\d\D]*?)(\)))", r"{1}", string)
+
+
+def convert(path):
+    content = path.read_text()
+
+    for method in [
+        doc_links,
+        download_links,
+        ref_links,
+        double_colon,
+        links_rst_to_markdown,
+        inline_code_rst_to_markdown,
+        link_placeholders,
+    ]:
+        print(method.__name__, end=" ")
+
+        content, subs = method(content)
+        print("." * subs)
+
+    Path(path.parent / path.name).write_text(content)
+
+
+if __name__ == "__main__":
+    for path in Path(sys.argv[1]).glob("**/*.po"):
+        print("=" * 5 + str(path) + "=" * 20)
+        convert(path)


### PR DESCRIPTION
@mhsmith Here are the scripts and processes I am using, as requested in the [Tutorial PR](https://github.com/beeware/beeware-tutorial/pull/3#issuecomment-3221719026).

## Converting documentation from rST to Markdown using Pandoc and a custom Python script

The Pandoc Markdown cleanup script was written initially with Toga in mind, but it applies to any Pandoc converted reStructuredText, including the BeeWare Tutorial. There are some hard-coded `toga` references in it, but those will be easy to update to work with Briefcase and Rubicon Objective-C, when/if the time comes.

To be clear, a significant portion of the specific work referenced in the Toga PR was manually done, as the point was to put together a proof of concept, not sort out my automation. The tutorial required much less manual intervention.

I ran a specific Pandoc command (included below) which is basically the best Pandoc can do in this case. Pandoc is not aware of the Python Markdown plugins I am using, and therefore cannot output everything exactly as needed. Therefore, I spent a significant amount of time early in this process going through every individual initially converted file in Toga and the BeeWare Tutorial, and extracted test strings for every bit of Pandoc-provided syntax that needed to be updated to work with the Python Markdown plugins I am using and my MkDocs configuration. I have included either the exact test strings from the documentation content, or pseudo-versions of what the strings look like, in the docstrings for most of the functions included in this script. I used them for testing, and it made sense to leave them in the file to make it clear what the regex is looking for.

The script takes the rST `:notation:` links into account, and updates them accordingly to render as they did in rST; I know this was a concern from a previous rST to Markdown conversion. The Pandoc command takes something like ":class:`~toga.sources.Row`" and converts it to "`~toga.sources.Row`{ interpreted-text role="class" }", which is what the clean-up script uses to generate the updated links. The script takes the `~` into account when generating the autorefs links, though the Toga PR brought some quirks of rST class/method links to Russ' attention, and it turns out he would prefer all methods be rendered appended to the class name, which is not consistent through the current documentation; I will be updating the script to address that change.

Worth noting a couple of things. I discovered the autorefs linking feature after writing a couple of the functions, so they may be written awkwardly or include unnecessary link info in the docstring (as in the Python doc-links function, for example). As well, a few of the functions are basically one-offs needed for odd notations that came out of the initial Pandoc conversion of Toga at the beginning of this process, and only apply to a couple of use cases. In my thorough search through Toga, I found that there were a couple of instances where an `include` was replaced with the actual text from the included file; I have addressed the instances I am aware of in the current PR, however I will need to search the existing documentation to make sure it didn't happen elsewhere as well. 

I have now run this script on both the BeeWare Tutorial, and Toga. It mostly handled the tutorial, however, it missed some obvious things in Toga, which highlighted places where it needs work. This is the first time I've worked with regexes, and, given that, I'm pretty happy with how well it worked on the first run. There are a few TODOs in the script that are either about when to run a particular function before or after another one, or something that needs to be addressed with the code.

Following running the script, I went through every updated file individually in the Tutorial with the intention of catching anything missed by the script, as well as cleaning up extra whitespace. I don't recall every bit of consistently missed syntax I had to manually fix. A few examples I remember: 

- I initially used autorefs links for the "Now go to the next page" links at the bottom of each of the tutorial pages, but autorefs links resolve to the associated anchor, which means, for those, it would navigate to the page with the title at the top and the header off-screen; I updated all of those to actual page links to avoid that issue.
- There was some consistent extra whitespace after the tab and admonition syntax, as well as a missed colon here and there from the Pandoc-converted tab and admonition syntax. So the regexes need to be updated there. 
- On the Toga run, I forgot to add backticks to the code-rendered autorefs links in the initial run, so there is also a function at the end that resolved that issue. I updated the actual link function to include the backticks, but left the followup function in case I didn't manage to catch all the places in the primary link function that needed backticks.
- Also on the Toga run, some of the `:notation:` links were missed on the first run of the script. The function that handles them is one of the most complicated functions in the script, so I quickly wrote up a second function to grab what was left. I couldn't get the regex to work with all of them in a reasonable amount of time, so for the ones that weren't isolated and updated by it, I added a `TODO` note, and then searched that and manually updated those that were left over.
- In some cases, the regex would miss improperly formatted links, which meant the beginning of one link was updated to `[`, and then a while later, the end of another link was updated to `]`. It is relatively straightforward to reliably find any missed links by searching the files for various parts of the rST link syntax, e.g. search for ">`__", or a regex search that searches for a single backtick followed by text followed by a "<". I was able to identify missed links this way, and it was a signal to verify that file for other missed links between the partially updated links. It's unclear why rST wasn't complaining about the links to begin with, but apparently it misses things. 

## Customised Pandoc command

I ran Pandoc with a modified `commonmark_x` output format, which is the basic CommonMark Markdown syntax, with a series of Pandoc extensions enabled by default. The following is the command. As it is written, it should be run in the `docs` directory, or it will convert any rST files it finds recursively from wherever you run it. Pandoc does not work recursively natively, so the `find` is necessary to run it on multiple files.

```
find -f **/*.rst -type f -exec sh -c 'pandoc -f rst "${0}" -t commonmark_x-bracketed_spans-smart-alerts -o "$(dirname {})/$(basename {} .rst).md"' {} \;
```

This command disables the `bracketed_spans`, `smart`, and `alerts` Pandoc extensions that are otherwise included with `commonmark_x`. They added a lot of unnecessary syntax to the Markdown that would have made a lot of extra work. I had already written the script before realising that I could modify the extensions included in a Pandoc command. There are a couple of other extensions that, if excluded, produce Markdown that is vaguely easier to work with, however, as I had already written most of the conversion script by the time I figured out the situation with disabling extensions, it made more sense to keep them included as I had already addressed the provided syntax. (I don't remember which extensions they were at this point.) Finally, it outputs the converted Markdown files alongside the rST files.

## Translation conversion

The translations were converted from rST formatting to Markdown by a separate script, also included here. Once the rST PO files were converted, I was able to generate a set of PO template files from the English Markdown, and use a translation tool called `pomerge` to merge the now-Markdown-formatted PO files into a new set of files that had the proper file locations with each `msg*` string pair. A few strings were lost due to major syntactical changes, but the majority of the translations were preserved, including the latest additions to the German translation.

The translation conversion script ran into some problems because it turns out the translations are loaded with improperly formatted links. Link issues I encountered: links wrapped in double quotes instead of backticks, links with spaces in them, links missing one of the backticks, links missing both backticks, links followed by only one underscore, and more I can't remember. I went through every PO file and searched for link formatting issues and resolved them manually.

## Docstring conversion

I have the early skeleton of a docstring conversion script. The docstrings in the source code for module documentation will need to be updated to use Markdown syntax for links etc. to render properly. I mostly did this manually for the Toga PR on the few files that I updated for the proof of concept, though I was able to run a single function to convert most of the rST links to Markdown autorefs format. I am not include it here as it is in the very early stages of development. I have not prioritised it yet, as a final decision hasn't been made regarding the Toga etc. switch to MkDocs.


## PR Checklist:
 <!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
 - [x] All new features have been tested
 - [x] All new features have been documented
 - [x] I have read the **CONTRIBUTING.md** file
 - [x] I will abide by the code of conduct