### PR TITLE
Align title on larger screens when version number absent.

### DIFF
--- a/docs/mkdocs.en.yml
+++ b/docs/mkdocs.en.yml
@@ -1,5 +1,5 @@
 INHERIT: config.yml
-site_name: BeeWare Docs Tools
+site_name: BeeWare Docs
 site_url: https://beeware-docs-tools.readthedocs.io/en/latest/
 docs_dir: en
 

--- a/src/beeware_docs_tools/overrides/assets/stylesheets/beeware_theme.css
+++ b/src/beeware_docs_tools/overrides/assets/stylesheets/beeware_theme.css
@@ -323,7 +323,7 @@
 }
 
 /* Sidebar title and GitHub links font and color */
-.md-nav__title * {
+.md-nav__title {
     font-family: 'Cutive', serif;
 }
 
@@ -333,17 +333,7 @@
 
 /* Site name */
 .site-name {
-    font-size: 20px;
-    padding-bottom: 8px;
-}
-
-.small .site-name {
-    padding-bottom: 0;
-}
-
-/* Sidebar title block */
-.sidebar-title-block {
-    margin-bottom: 24px;
+    font-size: 22px;
 }
 
 /* Version number */
@@ -351,6 +341,7 @@
     overflow-wrap: anywhere;
     font-size: 12px;
     font-weight: normal;
+    margin-top: 0.2rem;
 }
 
 /* GitHub sidebar links */
@@ -362,13 +353,21 @@
     color: light-dark(#084AFF, #526CFE);
 }
 
-.small .github-link-block {
-    margin-top: 16px;
+.github-link-block a:first-child .github-links {
+    margin-top: 0.8rem;
+    margin-bottom: 0.2rem;
 }
 
 .github-link-block a:last-child .github-links {
-    margin-top: 8px;
-    margin-bottom: 16px;
+    margin-bottom: 0.6rem;
+}
+
+.small .github-link-block a:first-child .github-links {
+    margin-top: 0.4rem;
+}
+
+.small .github-link-block a:last-child .github-links {
+    margin-bottom: 0.4rem;
 }
 
 /* Shows the logo in the sidebar */
@@ -376,14 +375,44 @@
     display: unset;
 }
 
-.mobile-site-name {
+/* Style the sidebar title block on primary pages and in sidebar drawer */
+.small .sidebar-title-block {
+    display: flex;
+    flex-flow: nowrap row;
+    align-items: center;
+}
+
+.small .sidebar-title-block-name {
+    align-items: start;
+}
+
+.sidebar-logo {
+    margin-bottom: 0.8em;
+    margin-top: 0.8em;
+    margin-right: 0.2rem;
+}
+
+/* Embiggen homepage logo */
+.md-nav__title .md-nav__button.md-logo img {
+    height: unset;
+}
+
+/* Embiggen sidebar drawer logo and match sidebar */
+.md-nav__title.small .md-nav__button.md-logo img {
+    height: unset;
+    max-width: unset;
+    width: 74px;
+}
+
+/* The menu button for the sidebar drawer to display the sidebar on smaller displays */
+.mobile-drawer-button-site-name {
     font-family: Cutive, "serif";
     font-size: 16px;
     display: inline-block;
     vertical-align: middle;
 }
 
-.mobile-version-number {
+.mobile-drawer-button-version-number {
     font-size: 12px;
     display: inline-block;
     vertical-align: middle;
@@ -391,33 +420,22 @@
     padding-left: 4px;
 }
 
-.mobile-sidebar-drawer {
+.mobile-sidebar-drawer-menu-bar {
     color: light-dark(#000000, #FFFFFF);
     background-color: light-dark(#F8F9FB, #4E4F52);
 }
 
 /* Adjustments for larger displays */
 @media screen and (min-width: 1220px) {
-    .md-nav__title .md-nav__button.md-logo img {
-        height: unset;
-    }
-
-    .md-nav__title.small .sidebar-logo {
-        float: left;
-        padding-left: 4px;
-        padding-right: 8px;
-        padding-bottom: 0 !important;
-        width: 74px;
-    }
-
-    .mobile-site-name, .mobile-version-number {
+    /* Hide menu bar when not needed */
+    .mobile-sidebar-drawer-menu-bar {
         display: none;
     }
 
     .sidebar-title-block-name {
-        display: grid;
+        display: flex;
+        flex-flow: nowrap column;
         align-items: center;
-        height: 62px;
     }
 }
 
@@ -431,10 +449,6 @@
         background-color: light-dark(#F8F9FB, #4E4F52);
     }
 
-    .md-nav--primary .md-nav__title .md-nav__icon {
-        position: relative;
-    }
-
     .md-nav--primary .md-nav__title {
         padding-top: 16px;
     }
@@ -444,29 +458,26 @@
         padding: 0;
     }
 
-    .md-nav__title .md-nav__button.md-logo img {
-        padding-bottom: 10px;
-        height: 60px;
-    }
-
+    /* Position of left sidebar */
     .md-sidebar.md-sidebar--secondary {
         top: 66px !important;
     }
 
+    /* Sidebar drawer header styling */
     .sidebar-logo {
-        height: 80px !important;
-        float: left;
-        padding-left: 4px;
-        padding-right: 8px;
-        padding-bottom: 0 !important;
-        width: 74px;
-        margin-bottom: 10px;
+        margin-right: 0.2rem;
     }
 
     .sidebar-title-block {
-        height: fit-content;
-        min-height: 60px;
-        margin-bottom: 42px;
+        display: flex;
+        flex-flow: nowrap row;
+        align-items: center;
+    }
+
+    .md-nav__title .md-nav__button.md-logo img {
+        height: unset;
+        max-width: unset;
+        width: 74px;
     }
 }
 

--- a/src/beeware_docs_tools/overrides/assets/stylesheets/beeware_theme.css
+++ b/src/beeware_docs_tools/overrides/assets/stylesheets/beeware_theme.css
@@ -428,6 +428,11 @@
     .mobile-site-name, .mobile-version-number {
         display: none;
     }
+
+    /* Site name when no version number is present */
+    .site-name-standalone {
+        padding-top: 16px;
+    }
 }
 
 /* Adjustments for smaller displays */

--- a/src/beeware_docs_tools/overrides/assets/stylesheets/beeware_theme.css
+++ b/src/beeware_docs_tools/overrides/assets/stylesheets/beeware_theme.css
@@ -346,23 +346,11 @@
     margin-bottom: 24px;
 }
 
-.small .sidebar-title-block {
-    height: fit-content;
-    min-height: 60px;
-    margin-bottom: 42px;
-}
-
 /* Version number */
 .version-number {
     overflow-wrap: anywhere;
     font-size: 12px;
     font-weight: normal;
-}
-
-.small .version-number {
-    padding-top: 10px;
-    justify-content: space-between;
-    display: grid;
 }
 
 /* GitHub sidebar links */
@@ -412,26 +400,24 @@
 @media screen and (min-width: 1220px) {
     .md-nav__title .md-nav__button.md-logo img {
         height: unset;
-        padding-bottom: 1rem;
     }
 
-    .md-nav__title.small .sidebar-logo img {
-        height: 80px !important;
+    .md-nav__title.small .sidebar-logo {
         float: left;
         padding-left: 4px;
         padding-right: 8px;
         padding-bottom: 0 !important;
         width: 74px;
-        margin-bottom: 10px;
     }
 
     .mobile-site-name, .mobile-version-number {
         display: none;
     }
 
-    /* Site name when no version number is present */
-    .site-name-standalone {
-        padding-top: 16px;
+    .sidebar-title-block-name {
+        display: grid;
+        align-items: center;
+        height: 62px;
     }
 }
 

--- a/src/beeware_docs_tools/overrides/partials/header.html
+++ b/src/beeware_docs_tools/overrides/partials/header.html
@@ -54,16 +54,16 @@
     {% endif %}
   </div>
 </nav>
-<div class="mobile-sidebar-drawer">
+<div class="mobile-sidebar-drawer-menu-bar">
     <!-- Button to open drawer -->
     <label class="md-header__button md-icon" for="__drawer">
         {% set icon = config.theme.icon.menu or "material/menu" %}
         {% include ".icons/" ~ icon ~ ".svg" %}
     </label>
-    <div class="mobile-site-name">
+    <div class="mobile-drawer-button-site-name">
         {{ config.site_name }}
     </div>
-    <div class="mobile-version-number">
+    <div class="mobile-drawer-button-version-number">
         {{ config.extra.version }}
     </div>
 </div>

--- a/src/beeware_docs_tools/overrides/partials/nav.html
+++ b/src/beeware_docs_tools/overrides/partials/nav.html
@@ -45,7 +45,7 @@
             <div class="sidebar-logo">
             {% include "partials/logo.html" %}
             </div>
-            <div class="site-name">
+            <div class="site-name{% if not config.extra.version %} site-name-standalone{% endif %}">
               {{ config.site_name }}
             </div>
             {% if config.extra.version %}

--- a/src/beeware_docs_tools/overrides/partials/nav.html
+++ b/src/beeware_docs_tools/overrides/partials/nav.html
@@ -45,14 +45,16 @@
             <div class="sidebar-logo">
             {% include "partials/logo.html" %}
             </div>
-            <div class="site-name{% if not config.extra.version %} site-name-standalone{% endif %}">
-              {{ config.site_name }}
+            <div class="sidebar-title-block-name">
+                <div class="site-name">
+                  {{ config.site_name }}
+                </div>
+                {% if config.extra.version %}
+                  <div class="version-number">
+                    {{ config.extra.version }}
+                  </div>
+                {% endif %}
             </div>
-            {% if config.extra.version %}
-              <div class="version-number">
-                {{ config.extra.version }}
-              </div>
-            {% endif %}
         </div>
     </a>
       <span class="github-link-block">


### PR DESCRIPTION
The logo was misaligned on the Tutorial because there is no version number present below it to take up the extra whitespace. This change centers the title on the logo. The logo on smaller screens is smaller, so the "BeeWare Tutorial" title appears to be aligned perfectly with it. Without shrinking the logo on the rest of the site, that can't be achieved. So I centered it on the logo instead. 

Tested with tutorial build. See screenshot.

<img width="386" height="217" alt="Screenshot 2025-08-27 at 19 35 56" src="https://github.com/user-attachments/assets/3e36ee1d-6833-402f-8896-ea72b27bcf20" />

## PR Checklist:
 <!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
 - [x] All new features have been tested
 - [x] All new features have been documented
 - [x] I have read the **CONTRIBUTING.md** file
 - [x] I will abide by the code of conduct
