### PR TITLE
Center homepage site name text when wrapped.

### DIFF
--- a/src/beeware_docs_tools/overrides/assets/stylesheets/beeware_theme.css
+++ b/src/beeware_docs_tools/overrides/assets/stylesheets/beeware_theme.css
@@ -333,7 +333,7 @@
 
 /* Site name */
 .site-name {
-    font-size: 22px;
+    font-size: 20px;
 }
 
 /* Version number */

--- a/src/beeware_docs_tools/overrides/assets/stylesheets/beeware_theme.css
+++ b/src/beeware_docs_tools/overrides/assets/stylesheets/beeware_theme.css
@@ -437,6 +437,14 @@
         flex-flow: nowrap column;
         align-items: center;
     }
+
+    .small .site-name {
+        text-align: start;
+    }
+
+    .site-name {
+        text-align: center;
+    }
 }
 
 /* Adjustments for smaller displays */


### PR DESCRIPTION
Centers homepage site name text on wider displays when site name is long enough to wrap onto two lines.

Will not show up in the RTD preview without manually lengthening the title from the inspector. 

<img width="311" height="382" alt="Screenshot 2025-08-28 at 13 43 44" src="https://github.com/user-attachments/assets/43cdfc5c-2a1f-41cf-b551-029f5cc13b23" />

## PR Checklist:
 <!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
 - [x] All new features have been tested
 - [x] All new features have been documented
 - [x] I have read the **CONTRIBUTING.md** file
 - [x] I will abide by the code of conduct
