### PR TITLE
Fix to remove `--upgrade pip` from build jobs.

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -12,7 +12,7 @@ build:
     # Docs are always built on Python 3.13. See also the tox config.
     python: "3.13"
   jobs:
-    post_install:
+    install:
       - python -m pip install --group 'dev'
     pre_build:
       - python -m tox -e docs-lint

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -12,8 +12,7 @@ build:
     # Docs are always built on Python 3.13. See also the tox config.
     python: "3.13"
   jobs:
-    pre_install:
-      - python -m pip install --upgrade pip
+    post_install:
       - python -m pip install --group 'dev'
     pre_build:
       - python -m tox -e docs-lint

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -12,7 +12,7 @@ build:
     # Docs are always built on Python 3.13. See also the tox config.
     python: "3.13"
   jobs:
-    install:
+    post_install:
       - python -m pip install --group 'dev'
     pre_build:
       - python -m tox -e docs-lint


### PR DESCRIPTION
Testing moving it from `pre_install` to `install`, which I am relatively sure fails. This is how it is shown in RTDs documentation. I want to verify this before moving it to the suggested `post_install`.

## PR Checklist:
 <!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
 - [x] All new features have been tested
 - [x] All new features have been documented
 - [x] I have read the **CONTRIBUTING.md** file
 - [x] I will abide by the code of conduct
