### PR TITLE
Add style guide, content test bed, and shared content workflow.

### DIFF
--- a/docs/config.yml
+++ b/docs/config.yml
@@ -66,7 +66,7 @@ markdown_extensions:
   pymdownx.blocks.tab:
     alternate_style: true
   pymdownx.snippets:
-    base_path: ["docs"]
+    base_path: ["docs", "shared_content"]
     url_download: true
     check_paths: true
   toc:

--- a/docs/en/SUMMARY.md
+++ b/docs/en/SUMMARY.md
@@ -4,3 +4,6 @@
 - [Section two](section_two/index.md)
 - [Section three](section_three/index.md)
     - ./section_three/*
+- Shared content test bed
+    - [Shared content test bed](content_test_bed/index.md)
+    - [Style guide](content_test_bed/style_guide_include.md)

--- a/docs/en/content_test_bed/index.md
+++ b/docs/en/content_test_bed/index.md
@@ -1,0 +1,16 @@
+# Shared content test bed
+
+This section is included for the purposes of verifying the shared content provided from this repo for use in the rest of the BeeWare documentation. "Shared content" refers to documents or sections of documents that are common to multiple other repos. They are stored here for inclusion across those repos. This means there is a single source when updates are required, and that change will populate across all repos using that shared content.
+
+If you are updating existing content, the following steps are not necessary. You can simply build the test site, and see your updates rendered.
+
+If you are creating a new shared documentation file in the `shared-content` directory, complete the following:
+
+1. Create a file in the `content_test_bed` that is the same filename as your new content file, with "_include" appended to the end.
+      * For `style_guide.md`, you would add `style_guide_include.md`.
+2. Using the Snippets syntax, add the filename to `filename_include.md`. The Snippets syntax for including content is `-8<- "filename.md"`.
+      * For `style_guide.md`, you would add `-8<- "style_guide.md"` to `style_guide_include.md`.
+3. Update the `Shared content test bed` section in `/docs/SUMMARY.md` to include the new `_include` file and path, at the same indentation level as the other items in that section.
+      * For `style_guide_include.md`, you would add `- [Style guide](content_test_bed/style_guide_include.md)`.
+
+Once these steps are completed, you can build the test site and view your new documentation rendered.

--- a/docs/en/content_test_bed/style_guide_include.md
+++ b/docs/en/content_test_bed/style_guide_include.md
@@ -1,0 +1,1 @@
+-8<- "style_guide.md"

--- a/shared_content/style_guide.md
+++ b/shared_content/style_guide.md
@@ -1,0 +1,362 @@
+# BeeWare documentation style guide
+
+This guide includes information on expected style, MkDocs-specific syntax, various required tools, and documentation translation, with regard to writing new content and translating existing content.
+
+## General style
+
+* Headers and titles should have only the first word capitalized.
+* We prefer US spelling, with some liberties for programming-specific colloquialism (e.g., "apps") and verbing of nouns (e.g., "scrollable").
+* The spelling of "artefact" and "artefacts" is as shown.
+* Any reference to a product name should use the product’s preferred capitalization. (e.g., "macOS", "GTK", "pytest", "Pygame", "PyScript").
+* If a term is being used "as code", then it should be quoted as inline code, by wrapping it in single backticks, rather than being added to the dictionary.
+
+## Reference Links
+
+MkDocs renders standard Markdown formatted links. It also supports rendering a reference link syntax that allows you to link to various other elements in the documentation using a modified Markdown link. This includes linking to, among other things, standard Markdown header anchors, custom Markdown header and text anchors, custom reference IDs, documented classes and class methods or attributes, and specific external documentation references.
+
+Standard Markdown formatted links are as follows:
+
+```markdown
+[Link text](https://url)
+```
+
+You can also use this format to link to a local file:
+
+```markdown
+[Link text](path/to/file.md)
+```
+
+Linking to an anchor _in the same file_ is formatted as follows:
+
+```markdown
+[Link text](#anchor-name)
+```
+
+Linking to an anchor _in a different_ file is formatted as follows:
+
+```markdown
+[Link text][anchor-name]
+```
+
+If you need to link to an anchor in a different file, and the anchor name is duplicated in multiple files, you can generate a custom anchor for the intended content (as shown in the next section), and link to that using the reference link formatting:
+
+```markdown
+[Link text][custom-anchor-name]
+```
+
+There are multiple options for linking to a documented class, or a class method or attribute, regardless of whether you are linking from the same file or a separate file. When linking to classes, etc., you must include backticks in the first set of square brackets to render the name as inline code. The backticks are not necessary only if you are using custom text that should not be rendered as inline code. Backticks should never be included in the second set of square brackets.
+
+Linking to a class while displaying the namespace is formatted as follows:
+
+```markdown
+[`module.ClassName`][]
+```
+
+Linking to a class while displaying only the class name is formatted as follows:
+
+```markdown
+[`ClassName`][module.ClassName]
+```
+
+Methods and attributes are the same as above, with the method or attribute name included. The following displays the namespace:
+
+```markdown
+[`module.ClassName.methodname`][]
+```
+
+The following displays the class and method name only:
+
+```markdown
+[`Classname.methodname`][module.Classname.methodname]
+```
+
+Linking to a class (or method) while displaying arbitrary text is formatted as follows:
+
+```markdown
+[link text][module.ClassName]
+```
+
+It is also possible to link directly to Python core documentation, as well as Pillow documentation. For example, to link to the documentation for `int`:
+
+```markdown
+[`int`][]
+```
+
+To link to the Pillow `Image` documentation:
+
+```markdown
+[`PIL.Image.Image`][]
+```
+
+## Custom Markdown anchors
+
+Markdown generates anchors for all headers (anything on a single line starting with between one and six `#` symbols), based on the content of the header. For example, the anchor generated for this section is `custom-markdown-anchors`. There are situations where it makes sense to instead set a custom anchor, such as, if the header is overly verbose, or you need something more memorable available for reuse.
+
+Changing the anchor for this section to `custom-anchors` would be done with the following formatting:
+
+```markdown
+## Custom Markdown anchors { id="custom-anchors" }
+```
+
+You can also create an anchor on general content, including text and codeblocks. The following formatting, with newlines above and below, should be included above the content you wish to link to:
+
+```markdown
+[](){ id="anchor-name" }
+```
+
+/// note | Note
+
+The reference linking that allows for linking to anchors in separate files requires that all anchors be unique. If you are creating a custom anchor, ensure that you are choosing a name that isn't used elsewhere in the documentation.
+
+///
+
+## Translating existing content
+
+The following items should _not_ be translated or updated:
+
+* Commands. For example, in "You should run \`briefcase create\`.", only "You should run" should be translated.
+* Namespaces; class, method, or attribute names. Reference links containing class, method or attribute names should be left as-is, including the backticks.
+* Jinja directives. This is any content wrapped inside `{{ }}` or `{% %}`.
+* Custom anchors. They are found after headers or above some content, and are formatted as `{ id="anchor" }`.
+* Admonition _syntax_. As shown below, the word "admonition" should not be translated. This goes for all styles of admonitions, including notes, warnings, etc. See below for information on translating the rest of the content.
+
+    ```markdown
+    /// admonition | Title
+
+    Content.
+
+    ///
+    ```
+
+* Backticks are meant to stay as backticks; they are used for formatting both inline code and code blocks.
+* The syntax for including external content. This is anything on the same line as `-8<-`, or on the lines between two `-8<-` on separate lines.
+
+The following items _should_ be translated:
+
+* The admonition titles and content. As shown below, "Title" and "Content." should be translated. See above for information on the syntax.
+
+    ```markdown
+    /// admonition | Title
+
+    Content.
+
+    ///
+    ```
+
+## Translations and writing new content
+
+Due to the way the translation files are generated, it is important to include required whitespace in the Markdown syntax for admonitions, notes, tabs, Jinja directives, image captions and alignment, etc.
+
+### Admonitions and notes
+Admonitions must be formatted as follows, including ensuring a newline before and after the admonition start and end:
+
+```markdown
+/// admonition | Title
+
+Admonition text, including
+multi-line text.
+
+A second paragraph.
+
+///
+```
+
+Note admonitions require the same formatting and newlines:
+
+```markdown
+/// note | Note
+
+Note text here.
+
+///
+```
+
+This format also works for attention, caution, danger, error, tip, hint, warning admonition types.
+
+### Tabbed content
+
+Tabbed content is formatted as follows, including a newline included before the start and after the end of the content block:
+
+```markdown
+/// tab | Tab one title
+
+Tab one text
+
+///
+
+/// tab | Tab two title
+
+Tab two text.
+
+///
+
+/// tab | Tab three title
+
+Tab three text.
+
+///
+```
+
+A tab with a nested admonition would be formatted as follows, including a newline before and after the content block:
+
+```markdown
+/// tab | Windows
+
+Tab text.
+
+/// admonition | Admonition
+
+Admonition text.
+
+///
+
+///
+```
+
+### Jinja directives
+
+There are a few features of the documentation that use Jinja directives in the text. Anything using the Jinja directive features needs to be wrapped in newlines. For example, the BeeWare tutorial contains Jinja conditionals based on variables to determine what admonition to show on the main page. Those are formatted as follows:
+
+```markdown
+{% if config.extra.translation_type == "original" %}
+
+/// admonition | Admonition title
+
+Text
+
+///
+
+{% endif %}
+```
+
+There is also syntax for substituting symbols or text. This syntax is a variable wrapped in `{{ }}`, and must include a newline before and after.
+
+### Images with caption syntax
+
+Whether the caption syntax is being utilized for the purposes of centering an image, or for providing an image caption, it must include newlines between each section.
+
+For example, when adding an empty caption to center an image, you should format it as follows, with a newline before and after the content block:
+
+```markdown
+![Alt text](/path/to/image.png)
+
+/// caption
+
+///
+```
+
+Adding a caption to an image also requires a newline before and after, and is formatted as follows:
+
+```markdown
+![Alt text](/path/to/image.png)
+
+/// caption
+
+Caption content.
+
+///
+```
+
+## Custom header anchors using reference IDs
+
+By default, Markdown generates an anchor for every header that is the text of the header with spaces and punctuation replaced with `-`. However, if you want something shorter, more memorable, or customised for whatever reason, this is possible using Jinja-formatted attribute IDs.
+
+The syntax is as follows:
+
+```markdown
+# Header text { id="anchor" }
+```
+
+For example, if you wanted to be able to link to this section using `custom-anchors`, you would format the header as follows:
+
+```markdown
+## Custom header anchors and reference IDs { id="custom-anchors" }
+```
+
+Once added, you can link to the section from within the same file using a standard Markdown link, or from another file using the reference link syntax.
+
+## Code block tricks
+
+### Language and code highlighting
+
+You can specify the language for the code contained within the codeblock by including the language name after the first three backticks, with no space between. This results in appropriate code highlighting when the code rendered. For example, to specify Python, you would begin the codeblock with the following:
+
+```
+```python
+```
+
+### Console commands and the copy button
+
+If you are including console commands, or commands with output, if you label it as `console` or `doscon`, depending on what operating system you are referencing, you can include the prompt, and only the command will be copied when clicking the copy button. For example, if you begin a codeblock with:
+
+```
+```console
+```
+
+And include the following content:
+
+```console
+$ mkdir test
+$ ls
+test
+```
+
+Then, clicking the copy button on the codeblock will copy only the commands, and ignore the prompts and the output. This allows you to indicate that they are console commands, while still allowing users to use the copy button effectively.
+
+### Highlighting specific lines of code
+
+Line highlighting:
+
+```markdown
+```python {hl_lines="2"}
+import toga
+from toga.style.pack import COLUMN, ROW
+```
+
+You can highlight multiple different lines. For example, `python {hl_lines="3 5 9"}` would highlight lines 3, 5 and 9. You can also highlight a range of lines. For example, `python {hl_lines="3-8"}` highlights lines 3 through 8. You can highlight multiple ranges with, for example, `python {hl_lines="9-18 23-44"}`.
+
+## Using Snippets to include external content
+
+For details on how to include external content from a local file or a URL, see the [Snippets documentation](https://facelessuser.github.io/pymdown-extensions/extensions/snippets/).
+
+Two important notes:
+
+* We use `-8<-` as the Snippets identifier. The documentation shows several options; please follow our style.
+* If you are including external content from a file on GitHub via a URL, you _must_ use the raw content URL, or it will render the webpage embedded wherever you include it.
+
+## Image formatting
+
+Images can have the width set, and can be aligned left, right, and center (with a caveat on "center").
+
+Setting the width of 300px on an image would be formatted as follows:
+
+```markdown
+![Image alt text](../path/to/image.png){ width="300px" }
+```
+
+Aligning an image left (or right) would be formatted as follows:
+
+```markdown
+![Image alt text](../path/to/image.png){ align=left }
+```
+
+Aligning an image center is not possible with the `align` attribute. The workaround is to follow the image with an empty caption, and it will be centered. You must include newlines between each section, and before and after. It is formatted as follows:
+
+```markdown
+![Image alt text](../path/to/image.png)
+
+/// caption
+
+///
+```
+
+## `pyspelling`
+
+We use the `pyspelling` spellchecker. It is run during the lint-checks.
+
+When `pyspelling` identifies a misspelled word, in most cases, it should be fixed in the documentation content.
+
+In the rare case that it identifies a valid word that isn't in the `pyspelling` dictionary, you have two options:
+
+1. If it is a word that is likely to be reused multiple times, you should add the word to the `spelling_wordlist` document in the `docs` directory, in alphabetical order.
+2. If it is a word that is unlikely to be used again, you can wrap it in a `<nospell>` / `</nospell>` tag, and `pyspelling` will ignore it inline.

--- a/tox.ini
+++ b/tox.ini
@@ -17,7 +17,7 @@ commands:
     translate : build_po_translations de fr
     lint : markdown-checker --dir {[docs]docs_dir} --func check_broken_urls
     lint : pyspelling
-    live : live_serve_en {posargs} src --source-code=src
+    live : live_serve_en {posargs} src shared_content --source-code=src
     all : build_md_translations {posargs} --source-code=src en de fr
     en : build_md_translations {posargs} --source-code=src en
     de : build_md_translations {posargs} --source-code=src de


### PR DESCRIPTION
This adds a style guide, which is intended to be shared across all MkDocs documentation repos. I made notes throughout the MkDocs transition process of content and syntax that requires specific formatting, as well as identifying consistent issues within the translations (though I have been informed that is likely the machine translation failing). This guide includes basic style suggestions, translation guidance, and details on quirks or new features of MkDocs not present in Sphinx. If you identify anything I missed and should include, please let me know.

To enable rendering the shared content, I have established a workflow for including new documentation in the test site build, so it is available for verification and review. The workflow for adding a new shared content document is included in `content_test_bed/index.md`. Editing existing documentation doesn't require any extra steps.

I have two reasons for the workflow suggested in `content_test_bed/index.md`:

1. Maintaining a separate directory for shared content, outside of the `docs` directory, creates a clearer delineation between the docs-tools test site, and the shared content. It also simplifies the include URL, which is not necessary, but is an incidental benefit.
2. All the shared content is intended to be rendered in separate repos by Snippets. Using Snippets to display it here ensures that no issues are present in the include process.

I had not been prioritising this document, however, with the Tutorial going live imminently, we will be reenabling translations, which means we need to be able to point translators to instructions on how to handle the new syntax that is included in the translation strings.

## PR Checklist:
 <!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
 - [x] All new features have been tested
 - [x] All new features have been documented
 - [x] I have read the **CONTRIBUTING.md** file
 - [x] I will abide by the code of conduct
