### PR TITLE
Add ruff to dependencies.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ dependencies = [
     "python-Levenshtein==0.27.1",
     "PyYAML==6.0.2",
     "polib==1.2.0",
+    "ruff==0.13.1",
     "translate-toolkit==3.16.1",
 ]
 


### PR DESCRIPTION
Ruff is needed to format class documentation signatures. It will be needed across all documentation that includes class docs.

## PR Checklist:
 <!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
 - [x] All new features have been tested
 - [x] All new features have been documented
 - [x] I have read the **CONTRIBUTING.md** file
 - [x] I will abide by the code of conduct
