### PR TITLE
Fix shared content issues.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,6 +75,8 @@ beeware_docs_tools = [
     "**/*.js",
     "**/*.png",
     "**/*.woff2",
+    "**/*.po",
+    "**/*.md",
 ]
 
 [tool.autocalver]

--- a/src/beeware_docs_tools/live_serve_en.py
+++ b/src/beeware_docs_tools/live_serve_en.py
@@ -80,11 +80,14 @@ def main():
         except KeyError:
             pass
 
+        base_path = config_file["markdown_extensions"]["pymdownx.snippets"].get(
+            "base_path", []
+        )
+
         shared_content_path = (Path(__file__).parent / "shared_content/en").resolve()
-        config_file["markdown_extensions"]["pymdownx.snippets"]["base_path"] = [
-            "docs",
-            str(shared_content_path),
-        ]
+        base_path.append(str(shared_content_path))
+
+        config_file["markdown_extensions"]["pymdownx.snippets"]["base_path"] = base_path
 
         with (temp_md_directory / "config.yml").open(
             "w", encoding="utf-8"


### PR DESCRIPTION
There were multiple issues with shared content and snippets.

* The way we were modifying the `base_path` for Snippets was overwriting local content, so any local changes were lost in the build. The modification code now appends the shared content path, instead of writing a hardcoded list.
* The way that we were symlinking the shared content in was not ideal, and was causing issues with invalid symlinks being left over on failures. This now symlinks into a temp directory instead of the actual docs/en directory.
* The shared content was not being included with docs-tools because the applicable package data was not included.

## PR Checklist:
 <!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
 - [x] All new features have been tested
 - [x] All new features have been documented
 - [x] I have read the **CONTRIBUTING.md** file
 - [x] I will abide by the code of conduct
