### PR TITLE
Unset spurious shadow on tab titles.

### DIFF
--- a/src/beeware_docs_tools/overrides/assets/stylesheets/beeware_theme.css
+++ b/src/beeware_docs_tools/overrides/assets/stylesheets/beeware_theme.css
@@ -584,6 +584,10 @@ readthedocs-docdiff {
     margin-left: 1rem;
 }
 
+.md-typeset .tabbed-labels {
+    box-shadow: unset;
+}
+
 .tabbed-content .tabbed-block {
     border: 2px solid #777777;
     padding: 0.5rem;


### PR DESCRIPTION
Caught this in Toga, and realised it needs to be dealt with globally.

## PR Checklist:
 <!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
 - [x] All new features have been tested
 - [x] All new features have been documented
 - [x] I have read the **CONTRIBUTING.md** file
 - [x] I will abide by the code of conduct
