### PR TITLE
Add --nofuzzymatching

### DIFF
--- a/src/beeware_docs_tools/build_po_translations.py
+++ b/src/beeware_docs_tools/build_po_translations.py
@@ -51,6 +51,7 @@ def pot_to_po(
             f"--template={Path.cwd() / docs / f'locales/{language}/translations.po'}",
             f"--input={Path.cwd() / docs / 'locales/template/translations.pot'}",
             f"--output={output_path / docs / language}",
+            "--nofuzzymatching",
         ],
         check=True,
     )


### PR DESCRIPTION
Adding or removing 'not' to a source string causes significant changes and thus we should not fuzzymatch.

<!--- Describe your changes in detail -->
<!--- What problem does this change solve? -->
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
