### PR TITLE
Bump rumdl-pre-commit from v0.0.147 to v0.0.153

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,7 +16,7 @@ repos:
         args: [ --fix ]
       - id: ruff-format
   - repo: https://github.com/rvben/rumdl-pre-commit
-    rev: v0.0.147
+    rev: v0.0.153
     hooks:
       - id: rumdl
         args: [--force-exclude]


### PR DESCRIPTION
Bumps `pre-commit` hook for `rumdl-pre-commit` from v0.0.147 to v0.0.153 and ran the update against the repo.