### PR TITLE
Bump ruff-pre-commit from v0.14.7 to v0.14.8

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
         exclude: "locales"
       - id: trailing-whitespace
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.14.7
+    rev: v0.14.8
     hooks:
       - id: ruff-check
         args: [ --fix ]


### PR DESCRIPTION
Bumps `pre-commit` hook for `ruff-pre-commit` from v0.14.7 to v0.14.8 and ran the update against the repo.