### PR TITLE
Fix self-copying button

### DIFF
--- a/src/beeware_docs_tools/overrides/assets/javascripts/copy_button.js
+++ b/src/beeware_docs_tools/overrides/assets/javascripts/copy_button.js
@@ -16,7 +16,7 @@ codeblocks.forEach((pre) => {
 
 // Excludes the button div, and the Pygments-tagged spans that are the console/doscon
 // shell prompt and the code output of a given command.
-const exclude = ["div.copy-button", "span.gp", "span.go"]
+const exclude = ["div.copy-button", "div.copy-button-copied", "span.gp", "span.go"]
 
 function filterText(target, exclusions) {
     // Clone as to not modify the live DOM.


### PR DESCRIPTION
Fixes #124

The copying already excludes the content of div.copy-button, but it doesn't exclude div.copy-button-copied. Therefore, if you click the button again while it's still in its "copied" state, you'll get the "Copied!" text in your clipboard. This should fix that.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] All new features have been tested
- [ ] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
