### PR TITLE
Fix scrolling to bottom of sidebars.

### DIFF
--- a/src/beeware_docs_tools/overrides/assets/stylesheets/beeware_theme.css
+++ b/src/beeware_docs_tools/overrides/assets/stylesheets/beeware_theme.css
@@ -577,6 +577,7 @@ body {
 @media screen and (min-width: 60em) {
     .md-sidebar__scrollwrap {
         margin-top: -64px;
+        padding-bottom: 4rem;  /* Scrollbar bugfix; enables scrolling to the bottom */
     }
 }
 


### PR DESCRIPTION
This issue is due to a JavaScript "feature" that handles the height of the sidebars, clashing with the changes we made to compensate for that feature so we could reclaim screen-space for the rest of the docs. 

Unfortunately, after several hours of fighting with it, this is the best solution I can work out. There will be a gap at the bottom of the sidebar if you scroll to the bottom of the page and the sidebar. However, it doesn't hide anything at the top, and you can always scroll back up. I spoke with Russ about it, and he can live with it. 

@mhsmith If you consider this suitable, please merge it at your convenience.

Fixes #148.

## PR Checklist:
 <!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
 - [x] All new features have been tested
 - [x] All new features have been documented
 - [x] I have read the **CONTRIBUTING.md** file
 - [x] I will abide by the code of conduct
