### PR TITLE
PROPOSAL:  Use 400 weight for H1 and H2, fall back to sans-serif for Simplified and Traditional Chinese headings

### DIFF
--- a/src/beeware_docs_tools/overrides/assets/stylesheets/beeware_theme.css
+++ b/src/beeware_docs_tools/overrides/assets/stylesheets/beeware_theme.css
@@ -6,16 +6,16 @@
 
 :root {
   --brand-font: "Cutive", serif;
+  color-scheme: light dark;
 }
 
+/* East Asian Languages can't use Cutive; fall back to sans-serif */
+:lang(ja),
+:lang(ko),
 :lang(zh),
 :lang(zh_CN),
 :lang(zh_TW) {
   --brand-font: "Cutive", sans-serif;
-}
-
-:root {
-    color-scheme: light dark;
 }
 
 [data-md-color-primary=indigo] {


### PR DESCRIPTION
<!--- Describe your changes in detail -->
<!--- What problem does this change solve? -->
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

[Test URL: https://beewareorg--10.org.readthedocs.build/zh-cn/10/]

The Chinese rendering for headings right now has very thin characters as compared to the english characters in Cutive:

<img width="479" height="68" alt="Screenshot 2026-01-28 at 19 19 23" src="https://github.com/user-attachments/assets/99a1f35f-e19b-42f8-8778-5e20d265ddd6" />

This is due to the fact that the default MkDocs theme wants H2 to be 300 weight, but Cutive does not have that thin of a weight, so it falls back onto the regular font weight, which is very thick for a "Regular" or 300 font.  Since not only Chinese but other non-Cutive fonts is likely to have this problem, I've bumped the weight for H1 and H2 to 400.

In addition, the serifs looks out of place in Chinese because the style (Songti / Mingti; I don't know which one) doesn't match the slab-serif style of Cutive.  Sans-Serif matches better, so I've added a variable for Chinese to use sans-serif in headings as well.

@freakboy3742 @kattni I'm interested in hearing thoughts on this change.  For reference, sans-serif Chinese with 400 weight:

<img width="402" height="76" alt="Screenshot 2026-01-28 at 19 19 04" src="https://github.com/user-attachments/assets/a8c7a776-0c11-41ea-bfed-cc2f0d495de5" />

Serif Chinese with 400 weight:

<img width="398" height="61" alt="Screenshot 2026-01-28 at 19 24 55" src="https://github.com/user-attachments/assets/050be119-8d54-4439-9b47-3c9ce34619b3" />



## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
