### PR TITLE
Restore javascript partial.

### DIFF
--- a/src/beeware_docs_tools/overrides/main.html
+++ b/src/beeware_docs_tools/overrides/main.html
@@ -35,7 +35,4 @@
 {% block scripts %}
     {{ super() }}
     <script src="{{ 'assets/javascripts/copy_button.js' | url }}"></script>
-    <script src="https://code.jquery.com/jquery-3.2.1.slim.min.js" integrity="sha384-KJ3o2DKtIkvYIK3UENzmM7KCkRr/rE9/Qpg6aAZGJwFDMVNA/GpGFF93hXpG5KkN" crossorigin="anonymous"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.11.0/umd/popper.min.js" integrity="sha384-b/U6ypiBEHpOf/4+1nzFpr53nxSS+GLCkfwBdFNTxtclqqenISfwAzpKaMNFNmj4" crossorigin="anonymous"></script>
-    <script src="https://beeware.org/static/bootstrap/js/bootstrap.min.js"></script>
 {% endblock %}

--- a/src/beeware_docs_tools/overrides/partials/javascripts/base.html
+++ b/src/beeware_docs_tools/overrides/partials/javascripts/base.html
@@ -1,1 +1,0 @@
-<!-- Override default stay-on-page handling -->


### PR DESCRIPTION
The partial removed in #171 was also responsible for enabling the dark-mode selector.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
