### PR TITLE
Correct link to CoC in footer.

### DIFF
--- a/src/beeware_docs_tools/overrides/partials/social.html
+++ b/src/beeware_docs_tools/overrides/partials/social.html
@@ -65,6 +65,6 @@
     </a>
   {% endfor %}
         <div class="footer-link">
-            <a href="https://beeware.org/coc">Code of Conduct</a>
+            <a href="https://beeware.org/bee/coc">Code of Conduct</a>
         </div>
 </div>


### PR DESCRIPTION
Fixes beeware/website#33.

The CoC link in the footer points at `/coc`, not `/bee/coc`

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
