### PR TITLE
Bump rumdl-pre-commit from v0.1.13 to v0.1.33

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,7 +16,7 @@ repos:
         args: [ --fix ]
       - id: ruff-format
   - repo: https://github.com/rvben/rumdl-pre-commit
-    rev: v0.1.13
+    rev: v0.1.33
     hooks:
       - id: rumdl
         args: []


### PR DESCRIPTION
Bumps `pre-commit` hook for `rumdl-pre-commit` from v0.1.13 to v0.1.33 and ran the update against the repo.