### PR TITLE
Allow for nested en content

### DIFF
--- a/src/beeware_docs_tools/build_md_translations.py
+++ b/src/beeware_docs_tools/build_md_translations.py
@@ -167,13 +167,16 @@ def main():
                 build_with_warnings=args.build_with_warnings,
             )
 
-        # If we've built EN, move the content into the root.
+        # If we've built EN, move the content into the root. The `en`` folder
+        # may contain an `en` folder; allow for that edge case by moving `en`
+        # to a safe location first.
         if "en" in args.language_code:
-            en_output = output / "en"
-            for path in en_output.iterdir():
+            en_orig = output / "en-nested"
+            shutil.move(output / "en", en_orig)
+            for path in en_orig.iterdir():
                 shutil.rmtree(output / path.name, ignore_errors=True)
                 shutil.move(path, output / path.name)
-            shutil.rmtree(en_output)
+            shutil.rmtree(en_orig)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
In order to allow for redirects that include `en`, the content reorganisation on the `build_md_translations` script needs to move the `en` folder out of the way before moving content out of that folder.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
