### PR TITLE
Improved merge strategy for en content

### DIFF
--- a/src/beeware_docs_tools/build_md_translations.py
+++ b/src/beeware_docs_tools/build_md_translations.py
@@ -167,24 +167,23 @@ def main():
                 build_with_warnings=args.build_with_warnings,
             )
 
-        for lang in args.language_code:
             # For every non-english language output: if there are language-folder
             # redirects, remove those from the translated version.
-            if lang != "en":
+            if language != "en":
                 for redirect_lang in args.language_code:
-                    lang_redirect = output / lang / redirect_lang
+                    lang_redirect = output / language / redirect_lang
                     if lang_redirect.is_dir():
                         print("Prune", lang_redirect)
                         shutil.rmtree(lang_redirect)
                     lang_redirect = (
-                        output / lang / redirect_lang.replace("_", "-").lower()
+                        output / language / redirect_lang.replace("_", "-").lower()
                     )
                     if lang_redirect.is_dir():
                         print("Prune", lang_redirect)
                         shutil.rmtree(lang_redirect)
 
             # If a SUMMARY/index.md has been created, prune it as well.
-            summary = output / lang / "SUMMARY"
+            summary = output / language / "SUMMARY"
             if summary.is_dir():
                 print("Prune", summary)
                 shutil.rmtree(summary)


### PR DESCRIPTION
The last step of building the translated docs is to move the `/en` folder into the root. However, if the en content contains redirects for languages, that merge process can collide with existing languages. This came up in tutorial, where we added redirects for `/de/latest` (et al); as the `/de` folder already existed, this led to the actual translated site content being deleted and overwritten with a redirect site.

This PR purges translations of language redirects; and also cleans up the SUMMARY content, if it has been generated.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
