### PR TITLE
Correct inconsistency in DE header translations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -218,3 +218,10 @@ git-log-head
 
 # macOS window layout file
 .DS_Store
+
+# IDEs and editors
+.vscode/
+.idea/
+
+# Local files
+local/

--- a/docs/mkdocs.de.yml
+++ b/docs/mkdocs.de.yml
@@ -12,6 +12,6 @@ extra:
     About: Über
     Documentation: Dokumentation
     Community: Gemeinschaft
-    Contributing: Mitwirken
-    News: Neuigkeiten
-    Sponsor: Förderer
+    Contributing: Beitrag leisten
+    News: Nachrichten
+    Sponsor: Sponsor


### PR DESCRIPTION
Docs tools has slightly different translations to what is in the main website translations for the DE headers.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
