### PR TITLE
Restore the language URLs that were mistakenly removed.

### DIFF
--- a/docs/mkdocs.ar.yml
+++ b/docs/mkdocs.ar.yml
@@ -7,6 +7,7 @@ theme:
   language: ar
 
 extra:
+  language_url: ar/
   translation_type: machine
   header:
     About: حول

--- a/docs/mkdocs.cs.yml
+++ b/docs/mkdocs.cs.yml
@@ -7,6 +7,7 @@ theme:
   language: cs
 
 extra:
+  language_url: cs/
   translation_type: machine
   header:
     About: O nás

--- a/docs/mkdocs.da.yml
+++ b/docs/mkdocs.da.yml
@@ -7,6 +7,7 @@ theme:
   language: da
 
 extra:
+  language_url: da/
   translation_type: machine
   header:
     About: Om

--- a/docs/mkdocs.de.yml
+++ b/docs/mkdocs.de.yml
@@ -7,6 +7,7 @@ theme:
   language: de
 
 extra:
+  language_url: de/
   translation_type: human
   header:
     About: Über

--- a/docs/mkdocs.es.yml
+++ b/docs/mkdocs.es.yml
@@ -7,6 +7,7 @@ theme:
   language: es
 
 extra:
+  language_url: es/
   translation_type: machine
   header:
     About: Acerca de

--- a/docs/mkdocs.fa.yml
+++ b/docs/mkdocs.fa.yml
@@ -7,6 +7,7 @@ theme:
   language: fa
 
 extra:
+  language_url: fa/
   translation_type: machine
   header:
     About: درباره

--- a/docs/mkdocs.fr.yml
+++ b/docs/mkdocs.fr.yml
@@ -7,6 +7,7 @@ theme:
   language: fr
 
 extra:
+  language_url: fr/
   translation_type: machine
   header:
     About: À propos

--- a/docs/mkdocs.it.yml
+++ b/docs/mkdocs.it.yml
@@ -7,6 +7,7 @@ theme:
   language: it
 
 extra:
+  language_url: it/
   translation_type: machine
   header:
     About: Informazioni

--- a/docs/mkdocs.ja.yml
+++ b/docs/mkdocs.ja.yml
@@ -7,6 +7,7 @@ theme:
   language: ja
 
 extra:
+  language_url: ja/
   translation_type: machine
   header:
     About: について

--- a/docs/mkdocs.ko.yml
+++ b/docs/mkdocs.ko.yml
@@ -7,6 +7,7 @@ theme:
   language: ko
 
 extra:
+  language_url: ko/
   translation_type: machine
   header:
     About: 소개

--- a/docs/mkdocs.pl.yml
+++ b/docs/mkdocs.pl.yml
@@ -7,6 +7,7 @@ theme:
   language: pl
 
 extra:
+  language_url: pl/
   translation_type: machine
   header:
     About: O

--- a/docs/mkdocs.pt.yml
+++ b/docs/mkdocs.pt.yml
@@ -7,6 +7,7 @@ theme:
   language: pt
 
 extra:
+  language_url: pt/
   translation_type: machine
   header:
     About: Sobre

--- a/docs/mkdocs.ru.yml
+++ b/docs/mkdocs.ru.yml
@@ -7,6 +7,7 @@ theme:
   language: ru
 
 extra:
+  language_url: ru/
   translation_type: machine
   header:
     About: О нас

--- a/docs/mkdocs.tr.yml
+++ b/docs/mkdocs.tr.yml
@@ -7,6 +7,7 @@ theme:
   language: tr
 
 extra:
+  language_url: tr/
   translation_type: machine
   header:
     About: Hakkında

--- a/docs/mkdocs.zh_CN.yml
+++ b/docs/mkdocs.zh_CN.yml
@@ -7,6 +7,7 @@ theme:
   language: zh
 
 extra:
+  language_url: zh_CN/
   translation_type: machine
   header:
     About: 关于

--- a/docs/mkdocs.zh_TW.yml
+++ b/docs/mkdocs.zh_TW.yml
@@ -7,6 +7,7 @@ theme:
   language: zh-TW
 
 extra:
+  language_url: zh_TW/
   translation_type: machine
   header:
     About: 關於


### PR DESCRIPTION
extra.language_url is needed to render translated header links.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
