### PR TITLE
Update logo to link dynamically to the current language homepage.

### DIFF
--- a/src/beeware_docs_tools/overrides/partials/header.html
+++ b/src/beeware_docs_tools/overrides/partials/header.html
@@ -37,7 +37,7 @@ aria-label="{{ lang.t('header') }}"
 
     <!-- Link to home -->
     <a
-      href="{{ config.extra.homepage | d(nav.homepage.url, true) | url }}"
+      href="https://beeware.org/{{ config.extra.language_url | default('') }}"
       title="{{ config.site_name | e }}"
       class="md-header__button md-logo"
       aria-label="{{ config.site_name }}"
@@ -57,7 +57,7 @@ aria-label="{{ lang.t('header') }}"
     <!-- Header title -->
     <div class="md-header__title" data-md-component="header-title">
       <div class="md-header__ellipsis">
-      <a href="{{ config.extra.homepage | d(nav.homepage.url, true) | url }}"
+      <a href="https://beeware.org/{{ config.extra.language_url | default('') }}"
          title="{{ config.site_name | e }}">
         <div class="md-header__topic">
           <span class="md-ellipsis">


### PR DESCRIPTION
The logo in the header has been pointing to the root of the current site. It should be pointing to beeware.org directly.

This does that with dynamic language handling.

## PR Checklist:
 <!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
 - [x] All new features have been tested
 - [x] All new features have been documented
 - [x] I have read the **CONTRIBUTING.md** file
 - [x] I will abide by the code of conduct
