### PR TITLE
Fix table font rendering globally, add test.

### DIFF
--- a/docs/en/section_one/index.md
+++ b/docs/en/section_one/index.md
@@ -24,6 +24,17 @@ https://raw.githubusercontent.com/beeware/beeware-docs-tools/refs/heads/main/doc
 
 <!-- rumdl-enable MD013 MD034 -->
 
+## Table font rendering
+
+Verify that the font in the following table is rendering at the same size as the rest of the font.
+
+| Column 1 | Column 2 |
+|----------|----------|
+| Row 1    | Row 1    |
+| Row 2    | Row 2    |
+| Row 3    | Row 3    |
+| Row 4    | Row 4    |
+
 ## Footer navigation
 
 Navigate to *Section One - Page Two* for the final check.

--- a/docs/en/section_one/page_two.md
+++ b/docs/en/section_one/page_two.md
@@ -8,6 +8,8 @@ Navigation should render at the bottom of the page; "BeeWare Docs Tools Demo Sec
 
 The following should show the reference documentation for the `DocsTest` class, located in `docs_test.py`, in the `src/beeware_docs_tools` directory. This verifies that the source code directory symlinking is working properly.
 
+Verify that the text in the parameter table is rendering at the same size as the rest of the font.
+
 ::: beeware_docs_tools.docs_test.DocsTest
 
 ## Macro functionality

--- a/src/beeware_docs_tools/overrides/assets/stylesheets/beeware_theme.css
+++ b/src/beeware_docs_tools/overrides/assets/stylesheets/beeware_theme.css
@@ -657,3 +657,8 @@ footer.md-footer *, html .md-footer-meta.md-typeset a  {
 .doc-signature {
     margin-left: 2em;
 }
+
+/* Table font rendering fix */
+.md-typeset table:not([class]) {
+    font-size: 1rem;
+}


### PR DESCRIPTION
The font issue was present in Rubicon as well, so it's worth doing the fix globally.

Tested with Rubicon.

Added a test case in the docs for verifying table rendering.

## PR Checklist:
 <!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
 - [x] All new features have been tested
 - [x] All new features have been documented
 - [x] I have read the **CONTRIBUTING.md** file
 - [x] I will abide by the code of conduct
