### PR TITLE
Docs fetch tags #147

### DIFF
--- a/src/beeware_docs_tools/shared_content/en/contribute/how/dev-environment.md
+++ b/src/beeware_docs_tools/shared_content/en/contribute/how/dev-environment.md
@@ -121,11 +121,11 @@ C:\...>git clone https://github.com/<your username>/{{ project_name }}.git
 
 {% endif %}
 
-#### Fetch tags from upstream
+#### Set an upstream repository
 
-/// info | Optional: Work with tags locally
+After cloning your fork, add the BeeWare repository as an `upstream` remote. This gives your local clone a reference to the original repository, making it easier to sync updates over time.
 
-If you need to work with tags locally, add the BeeWare repository as an `upstream` remote and fetch tags from it:
+You'll also need tags from `upstream` so tools like Toga and Briefcase can resolve accurate version numbers:
 
 {% if not config.extra.macos_only %}
 
@@ -169,8 +169,6 @@ $ git push --tags
 ```
 
 This can be useful if you make a fresh clone later and want tags to be available from your fork.
-
-///
 
 #### Create a virtual environment
 


### PR DESCRIPTION
Fixes #147

This PR adds documentation on how to fetch tags from the upstream repository when working from a fork, addressing the issue raised in #147.

Changes:
- Added optional section "Fetch tags from upstream" in the dev environment setup guide
- Includes instructions for adding upstream remote and fetching tags
- Added optional push-tags-to-fork guidance

Preview:
<img width="824" height="648" alt="screenshot of the change" src="https://github.com/user-attachments/assets/b0158769-2033-4c96-b3d5-08b7ab3809a4" />


## PR Checklist:

- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct