### PR TITLE
Shift Dependabot checks to weekly; this is a critical repo.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,9 +3,10 @@ version: 2
 multi-ecosystem-groups:
   dependencies:
     schedule:
-      # Check for updates on the first Sunday of every month, 8PM UTC
-      interval: "cron"
-      cronjob: "0 20 * * sun#1"
+      # Check for updates on Sunday, 8PM UTC
+      interval: "weekly"
+      day: "sunday"
+      time: "20:00"
 
 updates:
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
Per discussion, this shifts the Dependabot cadence from monthly to weekly, as this is considered critical infrastructure.

## PR Checklist:
 <!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
 - [x] All new features have been tested
 - [x] All new features have been documented
 - [x] I have read the **CONTRIBUTING.md** file
 - [x] I will abide by the code of conduct