### PR TITLE
Add NO_MKDOCS_2_WARNING environment variable

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -30,6 +30,7 @@ base_python = py313
 skip_install = true
 setenv =
     DISABLE_MKDOCS_2_WARNING = true
+    NO_MKDOCS_2_WARNING = 1
 passenv =
     DEEPL_API_KEY
     READTHEDOCS_CANONICAL_URL


### PR DESCRIPTION
<!--- Describe your changes in detail -->
<!--- What problem does this change solve? -->
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

There seems to be 2 env varibles needed to disable the MkDocs 2 warning.  FTR:  The release notes for 1.6.7 of ProperDocs has the specific techincal reasons this is happening, and https://github.com/squidfunk/mkdocs-material/issues/8581#issuecomment-4198060422 has notes on the actual conflict.

This PR adds the other environment variable.  Analogous changes are needed across all MkDocs documentation repos.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I will abide by the BeeWare Code of Conduct
- [x] I have read and have followed the **CONTRIBUTING.md** file
- [ ] This PR was generated or assisted using an AI tool