### PR TITLE
Bump rumdl-pre-commit from v0.1.67 to v0.1.87

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
         args: [ --fix ]
       - id: ruff-format
   - repo: https://github.com/rvben/rumdl-pre-commit
-    rev: v0.1.67
+    rev: v0.1.87
     hooks:
       - id: rumdl
       - id: rumdl-fmt


### PR DESCRIPTION
Bumps `pre-commit` hook for `rumdl-pre-commit` from v0.1.67 to v0.1.87 and ran the update against the repo.