### PR TITLE
Rolls back markdown-checker, removes flags no longer available.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ maintainers = [
 dependencies = [
     "click==8.3.3",
     "deepl==1.30.0",
-    "markdown-checker==1.0.2",
+    "markdown-checker==0.2.5",
     "mistletoe==1.5.1",
     "mkdocs-autorefs==1.4.4",
     "mkdocs-literate-nav==0.6.3",  # DO NOT UPGRADE - Uncertain whether author's move to ProperDocs will cause incompatibility

--- a/tox.ini
+++ b/tox.ini
@@ -47,8 +47,8 @@ commands:
     translate : build_po_translations ar cs da de es fa fr it ja ko pl pt ru tr vi zh_CN zh_TW -d {[docs]shared_content_dir}
     translate : update_machine_translations --soft-fail -d {[docs]shared_content_dir} ar cs da de es fa fr it ja ko pl pt ru tr vi zh_CN zh_TW
     lint : pyspelling
-    lint : markdown-checker --dir {[docs]docs_dir} --func check_broken_urls --timeout=50 --retries=10
-    lint : markdown-checker --dir {[docs]shared_content_dir} --func check_broken_urls --timeout=50 --retries=10 "--skip-urls-containing=https://app.readthedocs.org/projects/{{ project_name }}/,https://github.com/beeware/{{ project_name }},https://example.com/"
+    lint : markdown-checker --dir {[docs]docs_dir} --func check_broken_urls
+    lint : markdown-checker --dir {[docs]shared_content_dir} --func check_broken_urls "--skip-urls-containing=https://app.readthedocs.org/projects/{{ project_name }}/,https://github.com/beeware/{{ project_name }},https://example.com/"
     en : build_md_translations {posargs} --source-code=src en
     ar : build_md_translations {posargs} --source-code=src ar
     cs : build_md_translations {posargs} --source-code=src cs


### PR DESCRIPTION
## PR Checklist:
 <!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
 - [x] I will abide by the BeeWare Code of Conduct
 - [x] I have read and have followed the **CONTRIBUTING.md** file
 - [ ] This PR was generated or assisted using an AI tool
 <!-- update or delete the next line to reflect your usage -->
 Assisted-by: <!--name of tool; e.g., Claude Opus 4.5-->

