### PR TITLE
Include relevant items from original dev guide in updated code style guide #219

### DIFF
--- a/docs/spelling_wordlist
+++ b/docs/spelling_wordlist
@@ -23,6 +23,8 @@ Deutsch
 Dev
 dev
 Diataxis
+docstring
+docstrings
 else's
 Français
 GTK

--- a/src/beeware_docs_tools/shared_content/en/contribute/style/code-style-guide.md
+++ b/src/beeware_docs_tools/shared_content/en/contribute/style/code-style-guide.md
@@ -2,6 +2,22 @@ This guide includes information and guidelines for writing code for {{ formal_na
 
 ### Code style { #code-style }
 
+While type annotation adhering to [PEP 484](https://peps.python.org/pep-0484/) is optional, it remains strongly encouraged, particularly across any public API surfaces. 
+
+An example of a standard function definition with proper type hints and a Sphinx docstring is shown below:
+
+```py
+def function_name(param1: int, param2: str) -> bool:
+"""Example function with types and a docstring.
+
+:param param1: The first parameter.
+:param param2: The second parameter.
+
+:returns: The return value. True for success, False otherwise.
+"""
+```
+
+
 BeeWare follows [PEP 8](https://peps.python.org/pep-0008/) in our codebase, except with the line length expanded from 79 to 88 characters. We use [Ruff](https://docs.astral.sh/ruff/) to enforce PEP 8 conventions where possible. When you commit your code, pre-commit will run checks, including Ruff. Where possible, this will autoformat your code to ensure it meets our formatting and style standards. You can set up some IDEs to automatically run Ruff on save, which can help with the process.
 
 Keep in mind that the most important part of PEP 8 is [Section 0: A Foolish Consistency is the Hobgoblin of Little Minds](https://peps.python.org/pep-0008/#a-foolish-consistency-is-the-hobgoblin-of-little-minds). There are situations where remaining consistent with PEP 8 doesn't make sense, and it is important to understand that, when applicable, it is acceptable, and sometimes preferred, to write code that isn't in line with the rules listed. Knowing *when to be inconsistent* with those rules is as important as maintaining consistency in most situations.
@@ -64,3 +80,15 @@ my_function(
 We try to avoid `utils` modules as much as possible, with the understanding that sometimes they are unavoidable. The preferred alternative is to find somewhere for the feature elsewhere in the source code, instead of using a `utils` module.
 
 As a general rule, we try to avoid or defer any expensive initialization code, in order to achieve faster app startup. For instance, modules in the toga-core package are "lazy loaded" — they're only imported once requested, rather than all up front. This speeds up startup, and only spends time on what the app is actually using.
+
+When writing comments, avoid the use of first-person plural pronouns such as "we" (for example, write "Loop over" instead of "We loop over").
+
+In test docstrings, state the expected behavior that each test demonstrates. Don't include preambles such as "Tests that" or "Ensures that".
+
+Reserve ticket references for obscure issues where the ticket has additional details that can't be easily described in docstrings or comments. Include the ticket number at the end of a sentence like
+this:
+
+```py
+      def test_foo():
+          """A test docstring looks like this (#123456)."""
+```

--- a/src/beeware_docs_tools/shared_content/en/contribute/style/code-style-guide.md
+++ b/src/beeware_docs_tools/shared_content/en/contribute/style/code-style-guide.md
@@ -2,6 +2,19 @@ This guide includes information and guidelines for writing code for {{ formal_na
 
 ### Code style { #code-style }
 
+BeeWare follows [PEP 8](https://peps.python.org/pep-0008/) in our codebase, except with the line length expanded from 79 to 88 characters. We use [Ruff](https://docs.astral.sh/ruff/) to enforce PEP 8 conventions where possible. When you commit your code, pre-commit will run checks, including Ruff. Where possible, this will autoformat your code to ensure it meets our formatting and style standards. You can set up some IDEs to automatically run Ruff on save, which can help with the process.
+
+Keep in mind that the most important part of PEP 8 is [Section 0: A Foolish Consistency is the Hobgoblin of Little Minds](https://peps.python.org/pep-0008/#a-foolish-consistency-is-the-hobgoblin-of-little-minds). There are situations where remaining consistent with PEP 8 doesn't make sense, and it is important to understand that, when applicable, it is acceptable, and sometimes preferred, to write code that isn't in line with the rules listed. Knowing *when to be inconsistent* with those rules is as important as maintaining consistency in most situations.
+
+One manifestation of this can be seen in naming conventions. BeeWare libraries frequently need to bridge to other languages. When building wrappers to other languages, it is desirable (and in some cases, required) to follow the naming conventions of the target language, rather than Python. For example, when calling or referencing Java code, functions should follow Java's preference of `mixedCase`, rather than the PEP 8 preference for `snake_case`.
+
+We follow US spelling for API naming, variables, etc.
+
+{% block code_style %}
+{% endblock %}
+
+There are also some BeeWare-specific additions to PEP 8:
+
 While type annotation adhering to [PEP 484](https://peps.python.org/pep-0484/) is optional, it remains strongly encouraged, particularly across any public API surfaces.
 
 An example of a standard function definition with proper type hints and a Sphinx docstring is shown below:
@@ -16,19 +29,6 @@ def function_name(param1: int, param2: str) -> bool:
 :returns: The return value. True for success, False otherwise.
 """
 ```
-
-BeeWare follows [PEP 8](https://peps.python.org/pep-0008/) in our codebase, except with the line length expanded from 79 to 88 characters. We use [Ruff](https://docs.astral.sh/ruff/) to enforce PEP 8 conventions where possible. When you commit your code, pre-commit will run checks, including Ruff. Where possible, this will autoformat your code to ensure it meets our formatting and style standards. You can set up some IDEs to automatically run Ruff on save, which can help with the process.
-
-Keep in mind that the most important part of PEP 8 is [Section 0: A Foolish Consistency is the Hobgoblin of Little Minds](https://peps.python.org/pep-0008/#a-foolish-consistency-is-the-hobgoblin-of-little-minds). There are situations where remaining consistent with PEP 8 doesn't make sense, and it is important to understand that, when applicable, it is acceptable, and sometimes preferred, to write code that isn't in line with the rules listed. Knowing *when to be inconsistent* with those rules is as important as maintaining consistency in most situations.
-
-One manifestation of this can be seen in naming conventions. BeeWare libraries frequently need to bridge to other languages. When building wrappers to other languages, it is desirable (and in some cases, required) to follow the naming conventions of the target language, rather than Python. For example, when calling or referencing Java code, functions should follow Java's preference of `mixedCase`, rather than the PEP 8 preference for `snake_case`.
-
-We follow US spelling for API naming, variables, etc.
-
-{% block code_style %}
-{% endblock %}
-
-There are also some BeeWare-specific additions to PEP 8:
 
 #### Splitting long function calls { #split-long-function-calls }
 

--- a/src/beeware_docs_tools/shared_content/en/contribute/style/code-style-guide.md
+++ b/src/beeware_docs_tools/shared_content/en/contribute/style/code-style-guide.md
@@ -2,7 +2,7 @@ This guide includes information and guidelines for writing code for {{ formal_na
 
 ### Code style { #code-style }
 
-While type annotation adhering to [PEP 484](https://peps.python.org/pep-0484/) is optional, it remains strongly encouraged, particularly across any public API surfaces. 
+While type annotation adhering to [PEP 484](https://peps.python.org/pep-0484/) is optional, it remains strongly encouraged, particularly across any public API surfaces.
 
 An example of a standard function definition with proper type hints and a Sphinx docstring is shown below:
 
@@ -16,7 +16,6 @@ def function_name(param1: int, param2: str) -> bool:
 :returns: The return value. True for success, False otherwise.
 """
 ```
-
 
 BeeWare follows [PEP 8](https://peps.python.org/pep-0008/) in our codebase, except with the line length expanded from 79 to 88 characters. We use [Ruff](https://docs.astral.sh/ruff/) to enforce PEP 8 conventions where possible. When you commit your code, pre-commit will run checks, including Ruff. Where possible, this will autoformat your code to ensure it meets our formatting and style standards. You can set up some IDEs to automatically run Ruff on save, which can help with the process.
 
@@ -85,8 +84,7 @@ When writing comments, avoid the use of first-person plural pronouns such as "we
 
 In test docstrings, state the expected behavior that each test demonstrates. Don't include preambles such as "Tests that" or "Ensures that".
 
-Reserve ticket references for obscure issues where the ticket has additional details that can't be easily described in docstrings or comments. Include the ticket number at the end of a sentence like
-this:
+Reserve ticket references for obscure issues where the ticket has additional details that can't be easily described in docstrings or comments. Include the ticket number at the end of a sentence like this:
 
 ```py
       def test_foo():


### PR DESCRIPTION
…guide #219

<!--- Changes in detail -->
<!--- Added between Code-style section and before [PEP 8] content the following lines   -->
While type annotation adhering to [PEP 484](https://peps.python.org/pep-0484/) is optional, it remains strongly encouraged, particularly across any public API surfaces. 

An example of a standard function definition with proper type hints and a Sphinx docstring is shown below:

```py
def function_name(param1: int, param2: str) -> bool:
"""Example function with types and a docstring.

:param param1: The first parameter.
:param param2: The second parameter.

:returns: The return value. True for success, False otherwise.
"""
```

<!--- Added under section Things to avoid the following lines: -->
When writing comments, avoid the use of first-person plural pronouns such as "we" (for example, write "Loop over" instead of "We loop over").

In test docstrings, state the expected behavior that each test demonstrates. Don't include preambles such as "Tests that" or "Ensures that".

Reserve ticket references for obscure issues where the ticket has additional details that can't be easily described in docstrings or comments. Include the ticket number at the end of a sentence like
this:

```py
      def test_foo():
          """A test docstring looks like this (#123456)."""
```

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ x] I will abide by the BeeWare Code of Conduct
- [ ] I have read and have followed the **CONTRIBUTING.md** file
- [ ] This PR was generated or assisted using an AI tool
<!-- update or delete the next line to reflect your usage -->
Assisted-by: <!--name of tool; e.g., Claude Opus 4.5-->
