### PR TITLE
Add main links to mobile docs sidebar

### DIFF
--- a/src/beeware_docs_tools/overrides/assets/stylesheets/beeware_theme.css
+++ b/src/beeware_docs_tools/overrides/assets/stylesheets/beeware_theme.css
@@ -222,6 +222,10 @@ a.md-nav__link[for]:hover {
     color: light-dark(#084AFF, #526CFE);
 }
 
+.mobile-main-nav {
+    display: none;
+}
+
 .md-nav__item a.md-nav__link--active {
     color: light-dark(#30314B, #96ACEE)
 }
@@ -460,6 +464,10 @@ a.md-nav__link[for]:hover {
 @media screen and (max-width: 76.2344em) {
     [dir="ltr"] .md-sidebar--primary {
         width: 12.1rem;
+    }
+
+    .mobile-main-nav {
+        display: list-item;
     }
 
     .md-nav__title .md-nav__button.md-logo img {

--- a/src/beeware_docs_tools/overrides/partials/nav.html
+++ b/src/beeware_docs_tools/overrides/partials/nav.html
@@ -82,6 +82,38 @@
 
   <!-- Navigation list -->
   <ul class="md-nav__list" data-md-scrollfix>
+    {% if not config.extra.website %}
+      <li class="md-nav__item mobile-main-nav">
+        <a href="https://beeware.org/{{ config.extra.language_url | default('') }}about" class="md-nav__link">
+          {{ config.extra.header.About | default("About") }}
+        </a>
+      </li>
+      <li class="md-nav__item mobile-main-nav">
+        <a href="https://beeware.org/{{ config.extra.language_url | default('') }}docs" class="md-nav__link md-nav__link--active">
+          {{ config.extra.header.Documentation | default("Documentation") }}
+        </a>
+      </li>
+      <li class="md-nav__item mobile-main-nav">
+        <a href="https://beeware.org/{{ config.extra.language_url | default('') }}community" class="md-nav__link">
+          {{ config.extra.header.Community | default("Community") }}
+        </a>
+      </li>
+      <li class="md-nav__item mobile-main-nav">
+        <a href="https://beeware.org/{{ config.extra.language_url | default('') }}contributing" class="md-nav__link">
+          {{ config.extra.header.Contributing | default("Contributing") }}
+        </a>
+      </li>
+      <li class="md-nav__item mobile-main-nav">
+        <a href="https://beeware.org/{{ config.extra.language_url | default('') }}news" class="md-nav__link">
+          {{ config.extra.header.News | default("News") }}
+        </a>
+      </li>
+      <li class="md-nav__item mobile-main-nav">
+        <a href="https://beeware.org/{{ config.extra.language_url | default('') }}membership" class="md-nav__link">
+          {{ config.extra.header.Sponsor | default("Sponsor") }}
+        </a>
+      </li>
+    {% endif %}
     {% for nav_item in nav.items %}
       {% set path = "__nav_" ~ loop.index %}
       {{ item.render(nav_item, path, 1) }}

--- a/tests/test_theme_templates.py
+++ b/tests/test_theme_templates.py
@@ -1,0 +1,16 @@
+from pathlib import Path
+
+OVERRIDES = (
+    Path(__file__).parents[1]
+    / "src"
+    / "beeware_docs_tools"
+    / "overrides"
+)
+
+
+def test_mobile_sidebar_includes_main_site_links():
+    sidebar = (OVERRIDES / "partials" / "nav.html").read_text(encoding="utf-8")
+
+    assert "mobile-main-nav" in sidebar
+    for section in ["about", "docs", "community", "contributing", "news", "membership"]:
+        assert f"{section}\"" in sidebar

--- a/tests/test_theme_templates.py
+++ b/tests/test_theme_templates.py
@@ -1,11 +1,6 @@
 from pathlib import Path
 
-OVERRIDES = (
-    Path(__file__).parents[1]
-    / "src"
-    / "beeware_docs_tools"
-    / "overrides"
-)
+OVERRIDES = Path(__file__).parents[1] / "src" / "beeware_docs_tools" / "overrides"
 
 
 def test_mobile_sidebar_includes_main_site_links():
@@ -13,4 +8,4 @@ def test_mobile_sidebar_includes_main_site_links():
 
     assert "mobile-main-nav" in sidebar
     for section in ["about", "docs", "community", "contributing", "news", "membership"]:
-        assert f"{section}\"" in sidebar
+        assert f'{section}"' in sidebar


### PR DESCRIPTION
## Summary

- Add the BeeWare main-site header links to the docs mobile sidebar for project documentation sites.
- Keep those links hidden from the desktop sidebar so the existing desktop layout is unchanged.
- Add a template regression test that checks the mobile sidebar links are present.

Closes #208.

## Verification

- `venv/bin/python -m pytest tests/test_theme_templates.py -q` failed before the sidebar template change and passes after it.
- `venv/bin/python -m pytest -q`
- `venv/bin/ruff check src tests`
- `PATH=$PWD/venv/bin:$PATH SSL_CERT_FILE=$(venv/bin/python -m certifi) build_md_translations --source-code=src en`
- Generated `_build/html/index.html` contains mobile sidebar links for About, Documentation, Community, Contributing, News, and Sponsor.
- `git diff --check`

## AI-assisted work
This change was prepared with AI assistance and manually reviewed.