### PR TITLE
Prevent word wrap on translated content.

### DIFF
--- a/src/beeware_docs_tools/build_md_translations.py
+++ b/src/beeware_docs_tools/build_md_translations.py
@@ -64,6 +64,8 @@ def generate_translated_md(
             f"--template={docs_path / 'en'}",
             f"--output={output_path}",
             "--fuzzy",
+            # Don't wrap the output content (it can break translated links)
+            "--maxlinelength=0",
         ],
         check=True,
     )


### PR DESCRIPTION
Markdown doesn't like links to be broken mid-line, but po2md's output is wrapped by default at 80 chars.

This caused problems with the Tamil translation, as the content:
```
[Take the tutorial](https://tutorial.beeware.org){ .intro-tutorial }
```
was output as:
```
[கையேடுப் பயிற்சியை மேற்கொள்ளுங்கள்](https://tutorial.beeware.org){
.intro-tutorial }
```
causing the content to not be rendered as a button.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I will abide by the BeeWare Code of Conduct
- [x] I have read and have followed the **CONTRIBUTING.md** file
- [ ] This PR was generated or assisted using an AI tool
