### PR TITLE
Ensure code in a link adopts link text color.

### DIFF
--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -81,7 +81,7 @@ Sidebar links exist, and point to the `beeware-docs-tools` repo. This confirms t
 
 ## Link colors
 
-This link to [the main BeeWare website](https://beeware.org) should be blue in *both* light mode and dark mode.
+This link to [the main BeeWare website](https://beeware.org) should be blue in *both* light mode and dark mode. This link [that `INCLUDES CODE` markup](https://beeware.org) should use blue with a shaded background for the code content.
 
 The links in the left and right sidebars should also be blue in both modes.
 

--- a/src/beeware_docs_tools/overrides/assets/stylesheets/beeware_theme.css
+++ b/src/beeware_docs_tools/overrides/assets/stylesheets/beeware_theme.css
@@ -214,18 +214,6 @@ input.md-search__input, .md-search__suggest, .md-search-result__meta {
     color: unset;
 }
 
-/* Only color section header links as links */
-.md-typeset a,
-a.md-nav__link,
-a.md-nav__link[for]:focus,
-a.md-nav__link[for]:hover {
-    color: light-dark(#084AFF, #526CFE);
-}
-
-.md-nav__item a.md-nav__link--active {
-    color: light-dark(#30314B, #96ACEE)
-}
-
 /* Bump the font weight slightly for h1 and h2.  This will make fonts in some scripts,
    e.g. Chinese have more consistent weights with Cutive, which is thicker than most
    typical 300-weight fonts.  Cutive itself does not get emboldened by using 400.  */
@@ -292,6 +280,7 @@ a.md-nav__link[for]:hover {
 }
 
 .md-typeset a,
+.md-typeset a code,
 a.md-nav__link,
 a.md-nav__link[for]:focus,
 a.md-nav__link[for]:hover {


### PR DESCRIPTION
Ensure that code markup in link text is rendered with the link's text color, rather than reverting to the color of unlinked text.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I will abide by the BeeWare Code of Conduct
- [x] I have read and have followed the **CONTRIBUTING.md** file
- [ ] This PR was generated or assisted using an AI tool
