### PR TITLE
Fix builddocs live documentation

### DIFF
--- a/src/beeware_docs_tools/shared_content/en/_shared/contribute/how/build-docs.md
+++ b/src/beeware_docs_tools/shared_content/en/_shared/contribute/how/build-docs.md
@@ -13,7 +13,7 @@ To support rapid editing of documentation, {{ formal_name }} has a "live preview
 
 /// warning | The live preview will build with warnings!
 
-The live serve is available for iterating on your documentation updates. While you're in the process of updating things, you may introduce a markup issue. Issues considered a `WARNING` will cause a standard build to fail, however, the live serve is set up to indicate warnings in the console output, while continuing to build. This allows you to iterate without needing to restart the live preview.
+The live server is available for iterating on your documentation updates. While you're in the process of updating things, you may introduce a markup issue. Issues considered a `WARNING` will cause a standard build to fail, however, the live server is set up to indicate warnings in the console output, while continuing to build. This allows you to iterate without needing to restart the live preview.
 
 A `WARNING` is different from an `ERROR`. If you introduce an issue that is considered an `ERROR`, the live serve will fail, and require a restart. It will not start up again until the `ERROR` issue is resolved.
 

--- a/src/beeware_docs_tools/shared_content/en/_shared/contribute/how/build-docs.md
+++ b/src/beeware_docs_tools/shared_content/en/_shared/contribute/how/build-docs.md
@@ -15,7 +15,7 @@ To support rapid editing of documentation, {{ formal_name }} has a "live preview
 
 The live server is available for iterating on your documentation updates. While you're in the process of updating things, you may introduce a markup issue. Issues considered a `WARNING` will cause a standard build to fail, however, the live server is set up to indicate warnings in the console output, while continuing to build. This allows you to iterate without needing to restart the live preview.
 
-A `WARNING` is different from an `ERROR`. If you introduce an issue that is considered an `ERROR`, the live serve will fail, and require a restart. It will not start up again until the `ERROR` issue is resolved.
+A `WARNING` is different from an `ERROR`. If you introduce an issue that is considered an `ERROR`, the live server will fail, and require a restart. It will not start up again until the `ERROR` issue is resolved.
 
 ///
 

--- a/src/beeware_docs_tools/shared_content/en/_shared/contribute/how/build-docs.md
+++ b/src/beeware_docs_tools/shared_content/en/_shared/contribute/how/build-docs.md
@@ -15,7 +15,7 @@ To support rapid editing of documentation, {{ formal_name }} has a "live preview
 
 The live serve is available for iterating on your documentation updates. While you're in the process of updating things, you may introduce a markup issue. Issues considered a `WARNING` will cause a standard build to fail, however, the live serve is set up to indicate warnings in the console output, while continuing to build. This allows you to iterate without needing to restart the live preview.
 
-A `WARNING` is different from an `ERROR`. If you introduce an issue that is considered an `ERROR`, the live serve will fail, and require a restart. It will not start up again until the `WARNING` issue is resolved.
+A `WARNING` is different from an `ERROR`. If you introduce an issue that is considered an `ERROR`, the live serve will fail, and require a restart. It will not start up again until the `ERROR` issue is resolved.
 
 ///
 


### PR DESCRIPTION
<!--- Describe your changes in detail -->
<!--- What problem does this change solve? -->
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->
Fix the typos in Live documentation preview section:
- live serve**r** instead of live serve (missing letter)
- `ERROR` is the type of issue blocking live server run, instead of the `WARNING`

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I will abide by the BeeWare Code of Conduct
- [x] I have read and have followed the **CONTRIBUTING.md** file
- [ ] This PR was generated or assisted using an AI tool
<!-- update or delete the next line to reflect your usage -->
Assisted-by: <!--name of tool; e.g., Claude Opus 4.5-->
