### PR TITLE
Add zizmor pre-commit configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,13 +13,19 @@ updates:
     directory: "/"
     patterns: ["*"]
     multi-ecosystem-group: "dependencies"
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: "pip"
     directory: "/"
     patterns: ["*"]
     multi-ecosystem-group: "dependencies"
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: "pre-commit"
     directory: "/"
     patterns: ["*"]
     multi-ecosystem-group: "dependencies"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/check-pr-template.yml
+++ b/.github/workflows/check-pr-template.yml
@@ -7,4 +7,6 @@ on:
 jobs:
   check-pr-template:
     name: Check PR template
-    uses: beeware/.github/.github/workflows/pr-checklist.yml@main
+    permissions:
+      contents: read
+    uses: beeware/.github/.github/workflows/pr-checklist.yml@84508d17a1d29ee3b82ce2e467dcd38c4a0c6a5a  # main

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 defaults:
   run:
     shell: bash  # https://github.com/beeware/briefcase/pull/912
@@ -20,7 +23,7 @@ env:
 jobs:
   pre-commit:
     name: Pre-commit checks
-    uses: beeware/.github/.github/workflows/pre-commit-run.yml@main
+    uses: beeware/.github/.github/workflows/pre-commit-run.yml@84508d17a1d29ee3b82ce2e467dcd38c4a0c6a5a  # main
     with:
       pre-commit-source: "--group pre-commit"
 
@@ -30,12 +33,13 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Checkout
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           fetch-depth: 1
+          persist-credentials: false
 
       - name: Set up Python
-        uses: actions/setup-python@v6.3.0
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0
         with:
           python-version: "3.X"
           cache: pip
@@ -63,12 +67,13 @@ jobs:
     continue-on-error: false
     steps:
       - name: Checkout
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Set up Python
-        uses: actions/setup-python@v6.3.0
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0
         with:
           python-version: 3.12
 

--- a/.github/workflows/new-issue.yml
+++ b/.github/workflows/new-issue.yml
@@ -11,8 +11,11 @@ jobs:
   add-to-project:
     name: Add issue to BeeWare project
     runs-on: ubuntu-latest
+    # The add-to-project action authenticates with BRUTUS_PAT_TOKEN, so the
+    # job's own GITHUB_TOKEN needs no permissions.
+    permissions: {}
     steps:
-      - uses: actions/add-to-project@v2.0.0
+      - uses: actions/add-to-project@5afcf98fcd03f1c2f92c3c83f58ae24323cc57fd  # v2.0.0
         with:
           project-url: https://github.com/orgs/beeware/projects/1
           github-token: ${{ secrets.BRUTUS_PAT_TOKEN }}

--- a/.github/workflows/translate.yml
+++ b/.github/workflows/translate.yml
@@ -16,15 +16,19 @@ jobs:
     name: Update Translations
     if: github.actor != 'brutusthebee'
     runs-on: ubuntu-latest
+    # GitHub writes use BRUTUS_PAT_TOKEN, so the job's own GITHUB_TOKEN needs
+    # no permissions.
+    permissions: {}
     steps:
       - name: Checkout
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           fetch-depth: 1
           token: ${{ secrets.BRUTUS_PAT_TOKEN }}
+          persist-credentials: false
 
       - name: Set up Python
-        uses: actions/setup-python@v6.3.0
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0
         with:
           python-version: "3.X"
           cache: pip
@@ -39,9 +43,12 @@ jobs:
         run: python -m pip install --group translate
 
       - name: Configure git
+        env:
+          GH_TOKEN: ${{ secrets.BRUTUS_PAT_TOKEN }}
         run: |
           git config --local user.email "$(git log --pretty='%ae' -1)"
           git config --local user.name "brutusthebee[bot]"
+          gh auth setup-git
 
       - name: Configure Weblate
         env:
@@ -63,6 +70,8 @@ jobs:
       - name: Push Weblate changes
         run: wlc push
       - name: Pull translation updates pushed by Weblate
+        env:
+          GH_TOKEN: ${{ secrets.BRUTUS_PAT_TOKEN }}
         run: git pull origin
 
       - name: Regenerate PO files
@@ -83,7 +92,7 @@ jobs:
       - name: Commit updated translations
         if: steps.updated.outputs.updated == 'true'
         env:
-          GITHUB_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.BRUTUS_PAT_TOKEN }}
         run: |
           # Commit the updated PO files.
           git add docs/locales

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,3 +21,7 @@ repos:
     hooks:
       - id: rumdl
       - id: rumdl-fmt
+  - repo: https://github.com/zizmorcore/zizmor-pre-commit
+    rev: v1.28.0
+    hooks:
+      - id: zizmor


### PR DESCRIPTION
Adds zizmor to the pre-commit pipeline and resolves its findings by pinning actions and reusable workflows, applying least-privilege token permissions, and disabling persisted checkout credentials. Translation pulls and pushes continue to authenticate through `BRUTUS_PAT_TOKEN` using the GitHub CLI credential helper.

Also adds the requested seven-day Dependabot cooldown for all configured ecosystems.

Fixes #249
Fixes #250

## PR Checklist:
- [x] I will abide by the BeeWare Code of Conduct
- [x] I have read and have followed the **CONTRIBUTING.md** file
- [x] This PR was generated or assisted using an AI tool
Assisted-by: OpenAI Codex
