### PR TITLE
Add instruction to `cd` into repository after cloning it

### DIFF
--- a/src/beeware_docs_tools/shared_content/en/_shared/contribute/how/dev-environment.md
+++ b/src/beeware_docs_tools/shared_content/en/_shared/contribute/how/dev-environment.md
@@ -184,7 +184,6 @@ To set up a virtual environment and upgrade `pip`, run:
 {% endif %}
 
 ```console
-$ cd {{ project_name }}
 $ python3 -m venv .venv
 $ source .venv/bin/activate
 (.venv) $ python -m pip install -U pip
@@ -197,7 +196,6 @@ $ source .venv/bin/activate
 /// tab | Linux
 
 ```console
-$ cd {{ project_name }}
 $ python3 -m venv .venv
 $ source .venv/bin/activate
 (.venv) $ python -m pip install -U pip
@@ -208,7 +206,6 @@ $ source .venv/bin/activate
 /// tab | Windows
 
 ```doscon
-C:\...>cd {{ project_name }}
 C:\...>py -3 -m venv .venv
 C:\...>.venv\Scripts\activate
 (.venv) $ python -m pip install -U pip

--- a/src/beeware_docs_tools/shared_content/en/_shared/contribute/how/dev-environment.md
+++ b/src/beeware_docs_tools/shared_content/en/_shared/contribute/how/dev-environment.md
@@ -87,6 +87,7 @@ Fork the {{ formal_name }} repository, and then:
 
 ```console
 $ git clone https://github.com/<your username>/{{ project_name }}.git
+$ cd {{ project_name }}
 ```
 
 (substituting your GitHub username)
@@ -101,6 +102,7 @@ Fork the {{ formal_name }} repository, and then:
 
 ```console
 $ git clone https://github.com/<your username>/{{ project_name }}.git
+$ cd {{ project_name }}
 ```
 
 (substituting your GitHub username)
@@ -113,6 +115,7 @@ Fork the {{ formal_name }} repository, and then:
 
 ```doscon
 C:\...>git clone https://github.com/<your username>/{{ project_name }}.git
+C:\...>cd {{ project_name }}
 ```
 
 (substituting your GitHub username)


### PR DESCRIPTION
I saw this trip up someone at the PyCon sprints.

I think it makes more sense to include this immediately after the clone, rather than at the start of the following section, because it's easy for sections to be reordered or inserted, as has apparently already happened.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I will abide by the BeeWare Code of Conduct
- [x] I have read and have followed the **CONTRIBUTING.md** file
- [ ] This PR was generated or assisted using an AI tool
<!-- update or delete the next line to reflect your usage -->
Assisted-by: <!--name of tool; e.g., Claude Opus 4.5-->
