### PR TITLE
Clarify first push instructions

### DIFF
--- a/src/beeware_docs_tools/shared_content/en/_shared/contribute/how/submit-pr.md
+++ b/src/beeware_docs_tools/shared_content/en/_shared/contribute/how/submit-pr.md
@@ -166,7 +166,7 @@ The following shows an example of what to expect on `push`, with the URL highlig
 {% endif %}
 
 ```console {hl_lines="11"}
-(.venv) $ git push --set-upstream origin fix-win11-build
+(.venv) $ git push --set-upstream origin
 Enumerating objects: 15, done.
 Counting objects: 100% (15/15), done.
 Delta compression using up to 24 threads
@@ -189,7 +189,7 @@ To https://github.com/<your GitHub username>/{{ formal_name }}.git
 /// tab | Linux
 
 ```console {hl_lines="11"}
-(.venv) $ git push --set-upstream origin fix-win11-build
+(.venv) $ git push --set-upstream origin
 Enumerating objects: 15, done.
 Counting objects: 100% (15/15), done.
 Delta compression using up to 24 threads
@@ -210,7 +210,7 @@ To https://github.com/<your GitHub username>/{{ formal_name }}.git
 /// tab | Windows
 
 ```doscon {hl_lines="11"}
-(.venv) C:\...>git push --set-upstream origin fix-win11-build
+(.venv) C:\...>git push --set-upstream origin
 Enumerating objects: 15, done.
 Counting objects: 100% (15/15), done.
 Delta compression using up to 24 threads

--- a/src/beeware_docs_tools/shared_content/en/_shared/contribute/how/submit-pr.md
+++ b/src/beeware_docs_tools/shared_content/en/_shared/contribute/how/submit-pr.md
@@ -166,7 +166,7 @@ The following shows an example of what to expect on `push`, with the URL highlig
 {% endif %}
 
 ```console {hl_lines="11"}
-(.venv) $ git push
+(.venv) $ git push --set-upstream origin fix-win11-build
 Enumerating objects: 15, done.
 Counting objects: 100% (15/15), done.
 Delta compression using up to 24 threads
@@ -189,7 +189,7 @@ To https://github.com/<your GitHub username>/{{ formal_name }}.git
 /// tab | Linux
 
 ```console {hl_lines="11"}
-(.venv) $ git push
+(.venv) $ git push --set-upstream origin fix-win11-build
 Enumerating objects: 15, done.
 Counting objects: 100% (15/15), done.
 Delta compression using up to 24 threads
@@ -210,7 +210,7 @@ To https://github.com/<your GitHub username>/{{ formal_name }}.git
 /// tab | Windows
 
 ```doscon {hl_lines="11"}
-(.venv) C:\...>git push
+(.venv) C:\...>git push --set-upstream origin fix-win11-build
 Enumerating objects: 15, done.
 Counting objects: 100% (15/15), done.
 Delta compression using up to 24 threads
@@ -229,6 +229,10 @@ To https://github.com/<your GitHub username>/{{ formal_name }}.git
 ///
 
 {% endif %}
+
+The `--set-upstream` option tells Git to connect your local branch to the branch on your GitHub fork. You only need to include it the first time you push a new branch; after that, you can use `git push`.
+
+If GitHub asks for a password, don't enter your GitHub account password. GitHub no longer accepts account passwords for Git operations over HTTPS; follow GitHub's instructions for [creating and using a personal access token](https://docs.github.com/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token) instead.
 
 If you've previously pushed the current branch to GitHub, you won't receive the URL again. However, there are other ways to get to the PR creation URL:
 


### PR DESCRIPTION
Clarify the contribution guide's first-push instructions so contributors use `git push --set-upstream origin <branch>` and know to use a GitHub personal access token instead of their account password for HTTPS Git operations.

Fixes #258.

## PR Checklist:
- [x] I will abide by the BeeWare Code of Conduct
- [x] I have read and have followed the **CONTRIBUTING.md** file
- [x] This PR was generated or assisted using an AI tool
Assisted-by: OpenAI Codex

## Testing
- `git diff --check`
- `python3 -m compileall -q src/beeware_docs_tools`
- `uv run --with tox-uv tox -e docs-en`