### PR TITLE
Add zizmor.yml and relax pins on beeware/.github actions

### DIFF
--- a/.github/workflows/check-pr-template.yml
+++ b/.github/workflows/check-pr-template.yml
@@ -9,4 +9,4 @@ jobs:
     name: Check PR template
     permissions:
       contents: read
-    uses: beeware/.github/.github/workflows/pr-checklist.yml@84508d17a1d29ee3b82ce2e467dcd38c4a0c6a5a  # main
+    uses: beeware/.github/.github/workflows/pr-checklist.yml@main

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ env:
 jobs:
   pre-commit:
     name: Pre-commit checks
-    uses: beeware/.github/.github/workflows/pre-commit-run.yml@84508d17a1d29ee3b82ce2e467dcd38c4a0c6a5a  # main
+    uses: beeware/.github/.github/workflows/pre-commit-run.yml@main
     with:
       pre-commit-source: "--group pre-commit"
 

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,9 @@
+rules:
+  unpinned-uses:
+    config:
+      # Allow BeeWare-provided actions to be unpinned. If an attacker is in a
+      # position to exploit those action, they're probably able to exploit
+      # repositories directly; and it's significantly easier for our internal
+      # actions to automatically be the most recent versions.
+      policies:
+        beeware/*: ref-pin


### PR DESCRIPTION
Adds a `.github/zizmor.yml` config that allows `beeware/.github` action references to stay pinned to a ref (e.g. `@main`) instead of a full commit hash, and relaxes the existing `beeware/.github` action pins accordingly.

## PR Checklist:
- [x] I will abide by the BeeWare Code of Conduct
- [x] I have read and have followed the **CONTRIBUTING.md** file
- [x] This PR was generated or assisted using an AI tool
Assisted-by: Claude Sonnet 5
